### PR TITLE
Incremental update

### DIFF
--- a/astNodeType.mpl
+++ b/astNodeType.mpl
@@ -6,45 +6,45 @@
 "Variant"   includeModule
 
 AstNodeType: {
-  Empty:           [ 0 static] func;
-  Label:           [ 1 static] func;
-  Code:            [ 2 static] func;
-  Object:          [ 3 static] func;
-  List:            [ 4 static] func;
-  Name:            [ 5 static] func;
-  NameRead:        [ 6 static] func;
-  NameWrite:       [ 7 static] func;
-  NameMember:      [ 8 static] func;
-  NameReadMember:  [ 9 static] func;
-  NameWriteMember: [10 static] func;
-  String:          [11 static] func;
-  Numberi8:        [12 static] func;
-  Numberi16:       [13 static] func;
-  Numberi32:       [14 static] func;
-  Numberi64:       [15 static] func;
-  Numberix:        [16 static] func;
-  Numbern8:        [17 static] func;
-  Numbern16:       [18 static] func;
-  Numbern32:       [19 static] func;
-  Numbern64:       [20 static] func;
-  Numbernx:        [21 static] func;
-  Real32:          [22 static] func;
-  Real64:          [23 static] func;
+  Empty:           [ 0 static];
+  Label:           [ 1 static];
+  Code:            [ 2 static];
+  Object:          [ 3 static];
+  List:            [ 4 static];
+  Name:            [ 5 static];
+  NameRead:        [ 6 static];
+  NameWrite:       [ 7 static];
+  NameMember:      [ 8 static];
+  NameReadMember:  [ 9 static];
+  NameWriteMember: [10 static];
+  String:          [11 static];
+  Numberi8:        [12 static];
+  Numberi16:       [13 static];
+  Numberi32:       [14 static];
+  Numberi64:       [15 static];
+  Numberix:        [16 static];
+  Numbern8:        [17 static];
+  Numbern16:       [18 static];
+  Numbern32:       [19 static];
+  Numbern64:       [20 static];
+  Numbernx:        [21 static];
+  Real32:          [22 static];
+  Real64:          [23 static];
 };
 
 #AST Nodes
-IndexArray: [Int32 Array] func;
+IndexArray: [Int32 Array];
 
 NamedRecursiveBranch:[{
   children: IndexArray; # Array of Index
   name: String; # dynamic String
   nameInfo: 0 dynamic; #index in NameInfo pool
-}] func;
+}];
 
 NamedBranch: [{
   name: String; # dynamic String
   nameInfo: 0 dynamic; #index in NameInfo pool
-}] func;
+}];
 
 AstNode: [{
   virtual AST_NODE: ();
@@ -81,15 +81,15 @@ AstNode: [{
   ) Variant;
 
   INIT: []; DIE: []; # default life control, and ban uneffective copy, because object is too big
-}] func;
+}];
 
 makePositionInfo: [{
   column: copy;
   line: copy;
   offset: copy;
-}] func;
+}];
 
-PositionInfo: [-1 dynamic 1 dynamic 0 dynamic makePositionInfo] func;
+PositionInfo: [-1 dynamic 1 dynamic 0 dynamic makePositionInfo];
 
 ParserResult: [{
   virtual PARSER_RESULT: ();
@@ -102,9 +102,9 @@ ParserResult: [{
   nodes: IndexArray;
 
   INIT: []; DIE: []; # default life control, and ban uneffective copy, because object is too big
-}] func;
+}];
 
-ParserResults: [ParserResult Array] func;
+ParserResults: [ParserResult Array];
 
 MultiParserResult: [{
   names: String Int32 HashTable;
@@ -112,4 +112,4 @@ MultiParserResult: [{
   nodes: IndexArray Array; # order of going is not defined before compiling
 
   INIT: []; DIE: []; # default life control, and ban uneffective copy, because object is too big
-}] func;
+}];

--- a/astNodeType.mpl
+++ b/astNodeType.mpl
@@ -48,11 +48,11 @@ NamedBranch: [{
 
 AstNode: [{
   virtual AST_NODE: ();
-  token: String;
-  column: -1 dynamic;
-  line: -1 dynamic;
-  offset: -1 dynamic;
-  filename: 0 dynamic;
+  token:     String;
+  column:    -1 dynamic;
+  line:      -1 dynamic;
+  offset:    -1 dynamic;
+  fileNumber: 0 dynamic;
   data: (
     Cond                 #EmptyNode:
     NamedRecursiveBranch #LabelNode:

--- a/astOptimizers.mpl
+++ b/astOptimizers.mpl
@@ -10,7 +10,7 @@ optimizeLabelsInCurrentNode: [
     IndexArray @processedNodes.pushBack
     @recData AsRef @unfinishedNodes.pushBack
     0 @unfinishedIndexes.pushBack
-  ] func;
+  ];
 
   node.data.getTag AstNodeType.Label = [
     AstNodeType.Label @node.@data.get.@children TRUE addDataToProcess
@@ -29,7 +29,7 @@ optimizeLabelsInCurrentNode: [
       ] if
     ] if
   ] if
-] func;
+];
 
 optimizeLabels: [
   parserResult:;
@@ -81,7 +81,7 @@ optimizeLabels: [
       unfinishedNodes.getSize 0 >
     ] if
   ] loop
-] func;
+];
 
 optimizeNamesInCurrentNode: [
   node:;
@@ -95,13 +95,13 @@ optimizeNamesInCurrentNode: [
       ids.dataSize @nameWithInfo.@nameInfo set
       nameWithInfo.name ids.dataSize @ids.insert # copy string here
     ] if
-  ] func;
+  ];
 
   addToProcess: [
     data:;
     @data AsRef @unfinishedNodes.pushBack
     0 @unfinishedIndexes.pushBack
-  ] func;
+  ];
 
   node.data.getTag AstNodeType.Name < [
     node.data.getTag AstNodeType.Label = [
@@ -148,7 +148,7 @@ optimizeNamesInCurrentNode: [
       ] if
     ] if
   ] if
-] func;
+];
 
 optimizeNames: [
   multiParserResult:;
@@ -186,7 +186,7 @@ optimizeNames: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 concatParserResults: [
   mresult:;
@@ -200,7 +200,7 @@ concatParserResults: [
       cur: .@value;
       cur shift + @cur set
     ] each
-  ] func;
+  ];
 
   r: @results makeArrayRange;
 
@@ -229,4 +229,4 @@ concatParserResults: [
     shift current.memory.dataSize + @shift set
   ] each
 
-] func;
+];

--- a/build/compile.bat
+++ b/build/compile.bat
@@ -20,6 +20,7 @@ mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mp
  ../processSubNodes.mpl^
  ../staticCall.mpl^
  ../variable.mpl^
+ ../sl/ascii.mpl^
  ../sl/Array.mpl^
  ../sl/control.mpl^
  ../sl/conventions.mpl^

--- a/build/compile.bat
+++ b/build/compile.bat
@@ -9,6 +9,7 @@ mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mp
  ../builtins.mpl^
  ../codeNode.mpl^
  ../debugWriter.mpl^
+ ../defaultImpl.mpl^
  ../irWriter.mpl^
  ../main.mpl^
  ../parser.mpl^

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -20,6 +20,7 @@ mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll
  ../processSubNodes.mpl\
  ../staticCall.mpl\
  ../variable.mpl\
+ ../sl/ascii.mpl\
  ../sl/Array.mpl\
  ../sl/control.mpl\
  ../sl/conventions.mpl\

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -9,6 +9,7 @@ mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll
  ../builtins.mpl\
  ../codeNode.mpl\
  ../debugWriter.mpl\
+ ../defaultImpl.mpl\
  ../irWriter.mpl\
  ../main.mpl\
  ../parser.mpl\

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1008,7 +1008,7 @@ mplBuiltinCodeRef: [
       gnr: nullNode.varNameInfo getName;
       cnr: gnr captureName;
       refToVar: cnr.refToVar copy;
-      #("coderef captured var=" refToVar.hostId ":" refToVar.varId " g=" refToVar isGlobal) addLog
+      #("coderef captured var=" refToVar.hostId ":" refToVar.varId " s=" refToVar staticnessOfVar) addLog
 
       refToVar push
     ]

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1,6 +1,25 @@
 "builtinImpl" module
 "control" includeModule
 
+"codeNode" includeModule
+"processSubNodes" includeModule
+"defaultImpl" includeModule
+
+declareBuiltin: [
+  declareBuiltinName:;
+  declareBuiltinBody:;
+
+  {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;} () {} [
+    processorResult:;
+    processor:;
+    copy indexOfNode:;
+    currentNode:;
+    multiParserResult:;
+    failProc: @failProcForProcessor;
+    @declareBuiltinBody ucall
+  ] declareBuiltinName exportFunction
+];
+
 staticnessOfBinResult: [
   s1:; s2:;
   s1 Dynamic > not s2 Dynamic > not or [
@@ -71,33 +90,33 @@ mplNumberBinaryOp: [
   ] when
 ] func;
 
-mplBuiltinAdd: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fadd" makeStringView]["add" makeStringView] if] [+] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinAdd" declareBuiltin ucall
 
-mplBuiltinSub: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fsub" makeStringView]["sub" makeStringView] if] [-] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinSub" declareBuiltin ucall
 
-mplBuiltinMul: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fmul" makeStringView]["mul" makeStringView] if] [*] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinMul" declareBuiltin ucall
 
-mplBuiltinDiv: [
+[
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fdiv" makeStringView][a2 isNat ["udiv" makeStringView] ["sdiv" makeStringView] if] if] [/] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] func;
+] "mplBuiltinDiv" declareBuiltin ucall
 
-mplBuiltinMod: [
+[
   VarNat8 VarIntX 1 + [a2:; a1:; a2 isNat ["urem" makeStringView] ["srem" makeStringView] if] [mod] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] func;
+] "mplBuiltinMod" declareBuiltin ucall
 
-mplBuiltinEqual: [
+[
   arg2: pop;
   arg1: pop;
 
@@ -162,19 +181,19 @@ mplBuiltinEqual: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinEqual" declareBuiltin ucall
 
-mplBuiltinLess: [
+[
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp olt" makeStringView][a2 isNat ["icmp ult" makeStringView] ["icmp slt" makeStringView] if] if
   ] [<] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinLess" declareBuiltin ucall
 
-mplBuiltinGreater: [
+[
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp ogt" makeStringView][a2 isNat ["icmp ugt" makeStringView] ["icmp sgt" makeStringView] if] if
   ] [>] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinGreater" declareBuiltin ucall
 
 mplNumberUnaryOp: [
   exValidator:;
@@ -221,44 +240,44 @@ mplNumberUnaryOp: [
   ] when
 ] func;
 
-mplBuiltinNot: [
+[
   VarCond VarNatX 1 + [a:; "xor" makeStringView] [
     a:; a getVar.data.getTag VarCond = ["true, " makeStringView]["-1, " makeStringView] if
   ] [not] [x:;] mplNumberUnaryOp
-] func;
+] "mplBuiltinNot" declareBuiltin ucall
 
-mplBuiltinXor: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "xor" makeStringView] [xor] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinXor" declareBuiltin ucall
 
-mplBuiltinAnd: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "and" makeStringView] [and] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinAnd" declareBuiltin ucall
 
-mplBuiltinOr: [
+[
   VarCond VarNatX 1 + [a2:; a1:; "or" makeStringView] [or] [copy] [y:; x:;] mplNumberBinaryOp
-] func;
+] "mplBuiltinOr" declareBuiltin ucall
 
-mplBuiltinTrue: [
+[
   TRUE VarCond createVariable createPlainIR push
-] func;
+] "mplBuiltinTrue" declareBuiltin ucall
 
-mplBuiltinFalse: [
+[
   FALSE VarCond createVariable createPlainIR push
-] func;
+] "mplBuiltinFalse" declareBuiltin ucall
 
-mplBuiltinLF: [
+[
   s: LF toString;
   s VarString createVariable createStringIR push
-] func;
+] "mplBuiltinLF" declareBuiltin ucall
 
-mplBuiltinNeg: [
+[
   VarInt8 VarReal64 1 + [
     a:; a isAnyInt ["sub" makeStringView]["fsub" makeStringView] if
   ] [
     a:; a isAnyInt ["0, " makeStringView]["0x0000000000000000, " makeStringView] if
   ] [neg] [x:;] mplNumberUnaryOp
-] func;
+] "mplBuiltinNeg" declareBuiltin ucall
 
 mplNumberBuiltinOp: [
   exValidator:;
@@ -313,49 +332,49 @@ mplNumberBuiltinOp: [
   ] when
 ] func;
 
-mplBuiltinSin: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sin.f32" makeStringView]["@llvm.sin.f64" makeStringView] if
   ] [sin] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinSin" declareBuiltin ucall
 
-mplBuiltinCos: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.cos.f32" makeStringView]["@llvm.cos.f64" makeStringView] if
   ] [cos] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinCos" declareBuiltin ucall
 
-mplBuiltinSqrt: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sqrt.f32" makeStringView]["@llvm.sqrt.f64" makeStringView] if
   ] [sqrt] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinSqrt" declareBuiltin ucall
 
-mplBuiltinCeil: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.ceil.f32" makeStringView]["@llvm.ceil.f64" makeStringView] if
   ] [ceil] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinCeil" declareBuiltin ucall
 
-mplBuiltinFloor: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.floor.f32" makeStringView]["@llvm.floor.f64" makeStringView] if
   ] [floor] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinFloor" declareBuiltin ucall
 
-mplBuiltinLog: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log.f32" makeStringView]["@llvm.log.f64" makeStringView] if
   ] [log] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinLog" declareBuiltin ucall
 
-mplBuiltinLog10: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log10.f32" makeStringView]["@llvm.log10.f64" makeStringView] if
   ] [log10] [x:;] mplNumberBuiltinOp
-] func;
+] "mplBuiltinLog10" declareBuiltin ucall
 
-mplBuiltinPow: [
+[
   TRUE dynamic @processor.@usedFloatBuiltins set
   arg2: pop;
   arg1: pop;
@@ -416,7 +435,7 @@ mplBuiltinPow: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinPow" declareBuiltin ucall
 
 mplShiftBinaryOp: [
   opFunc:;
@@ -474,63 +493,19 @@ mplShiftBinaryOp: [
   ] when
 ] func;
 
-mplBuiltinLShift: [
+[
   [t2:; t1:; "shl" makeStringView][lshift] mplShiftBinaryOp
-] func;
+] "mplBuiltinLShift" declareBuiltin ucall
 
-mplBuiltinRShift: [
+[
   [t2:; t1:; t1 isNat ["lshr" makeStringView]["ashr" makeStringView] if][rshift] mplShiftBinaryOp
-] func;
+] "mplBuiltinRShift" declareBuiltin ucall
 
-createRef: [
-  mutable:;
-  refToVar:;
-  refToVar isVirtual [
-    refToVar untemporize
-    refToVar copy #for dropping or getting callables for example
-  ] [
-    var: refToVar getVar;
-    #var.temporary [var.data.getTag VarRef = not] && [
-    #  "getting ref to temporary var" compilerError
-    #] [
-    refToVar staticnessOfVar Weak = [Dynamic @var.@staticness set] when
-    refToVar fullUntemporize
+[TRUE defaultRef] "mplBuiltinRef" declareBuiltin ucall
+[FALSE defaultRef] "mplBuiltinCref" declareBuiltin ucall
+[TRUE defaultMakeConstWith] "mplBuiltinConst" declareBuiltin ucall
 
-    newRefToVar: refToVar VarRef createVariable;
-    mutable refToVar.mutable and @newRefToVar.@mutable set
-    refToVar newRefToVar createRefOperation
-    newRefToVar
-    #] if
-  ] if
-] func;
-
-mplProcessRef: [
-  copy mutable:;
-  refToVar: pop;
-  compilable [
-    refToVar mutable createRef push
-  ] when
-] func;
-
-mplBuiltinRef: [TRUE mplProcessRef] func;
-mplBuiltinCref: [FALSE mplProcessRef] func;
-
-mplBuiltinConstWith: [
-  copy check:;
-  refToVar: pop;
-  compilable [
-    check [refToVar getVar.temporary copy] && [
-      "temporary objects cannot be set const" compilerError
-    ] [
-      FALSE @refToVar.@mutable set
-      refToVar push
-    ] if
-  ] when
-] func;
-
-mplBuiltinConst: [TRUE mplBuiltinConstWith] func;
-
-mplBuiltinDeref: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarRef = [
@@ -543,29 +518,13 @@ mplBuiltinDeref: [
       "not a reference" makeStringView compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinDeref" declareBuiltin ucall
 
-mplBuiltinCall: [
-  refToVar: pop;
-  compilable [
-    var: refToVar getVar;
-    var.data.getTag VarCode = [
-      VarCode var.data.get "call" makeStringView processCall
-    ] [
-      var.data.getTag VarImport = [
-        refToVar processFuncPtr
-      ] [
-        refToVar isCallable [
-          RefToVar refToVar "call" makeStringView callCallableStruct # call struct with INVALID object
-        ] [
-          "not callable" makeStringView compilerError
-        ] if
-      ] if
-    ] if
-  ] when
-] func;
+[
+  defaultCall
+] "mplBuiltinCall" declareBuiltin ucall
 
-mplBuiltinUcall: [
+[
   code: pop;
 
   compilable [
@@ -581,63 +540,33 @@ mplBuiltinUcall: [
       indexArray addIndexArrayToProcess
     ] when
   ] when
-] func;
+] "mplBuiltinUcall" declareBuiltin ucall
 
-mplBuiltinDynamic: [
+[
   refToVar: pop;
   compilable [
     refToVar makeVarTreeDynamic
     refToVar push
   ] when
-] func;
+] "mplBuiltinDynamic" declareBuiltin ucall
 
-mplBuiltinDirty: [
+[
   refToVar: pop;
   compilable [
     refToVar makeVarTreeDirty
     refToVar push
   ] when
-] func;
+] "mplBuiltinDirty" declareBuiltin ucall
 
-mplBuiltinStatic: [
+[
   refToVar: pop;
   compilable [
     refToVar staticnessOfVar Weak = [refToVar Static makeStaticness @refToVar set] when
     refToVar push
   ] when
-] func;
+] "mplBuiltinStatic" declareBuiltin ucall
 
-mplBuiltinSet: [
-  refToDst: pop;
-  refToSrc: pop;
-
-  compilable [
-    refToDst refToSrc variablesAreSame [
-      refToSrc getVar.data.getTag VarImport = [
-        "functions cannot be copied" compilerError
-      ] [
-        refToDst.mutable [
-          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
-          refToSrc refToDst createCopyToExists
-        ] [
-          "destination is immutable" compilerError
-        ] if
-      ] if
-    ] [
-      refToDst.mutable not [
-        "destination is immutable" compilerError
-      ] [
-        lambdaCastResult: refToSrc refToDst tryImplicitLambdaCast;
-        lambdaCastResult.success [
-          newSrc: lambdaCastResult.refToVar TRUE createRef;
-          newSrc refToDst createCopyToExists
-        ] [
-          ("types mismatch, src is " refToSrc getMplType "," LF "dst is " refToDst getMplType) assembleString compilerError
-        ] if
-      ] if
-    ] if
-  ] when
-] func;
+[defaultSet] "mplBuiltinSet" declareBuiltin ucall
 
 mplBuiltinProcessAtList: [
   refToStruct: pop;
@@ -733,21 +662,21 @@ mplBuiltinProcessAtList: [
   result
 ] func;
 
-mplBuiltinAt: [
+[
   field: mplBuiltinProcessAtList;
   compilable [
     field derefAndPush
   ] when
-] func;
+] "mplBuiltinAt" declareBuiltin ucall
 
-mplBuiltinExclamation: [
+[
   field: mplBuiltinProcessAtList;
   compilable [
     field setRef
   ] when
-] func;
+] "mplBuiltinExclamation" declareBuiltin ucall
 
-mplBuiltinIf: [
+[
   else: pop;
   then: pop;
   condition: pop;
@@ -777,9 +706,9 @@ mplBuiltinIf: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinIf" declareBuiltin ucall
 
-mplBuiltinUif: [
+[
   else: pop;
   then: pop;
   condition: pop;
@@ -806,9 +735,9 @@ mplBuiltinUif: [
       ] if
     ] when
   ] when
-] func;
+] "mplBuiltinUif" declareBuiltin ucall
 
-mplBuiltinLoop: [
+[
   body: pop;
 
   (
@@ -821,7 +750,7 @@ mplBuiltinLoop: [
       astNode processLoop
     ]
   ) sequence
-] func;
+] "mplBuiltinLoop" declareBuiltin ucall
 
 parseFieldToSignatureCaptureArray: [
   refToStruct:;
@@ -912,7 +841,7 @@ parseSignature: [
   result
 ] func;
 
-mplBuiltinExportFunction: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["export must be global" compilerError] when]
@@ -933,9 +862,9 @@ mplBuiltinExportFunction: [
       index: signature astNode VarString varName.data.get makeStringView FALSE dynamic processExportFunction;
     ]
   ) sequence
-] func;
+] "mplBuiltinExportFunction" declareBuiltin ucall
 
-mplBuiltinExportVariable: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["export must be global" compilerError] when]
@@ -977,9 +906,9 @@ mplBuiltinExportVariable: [
       ] when
     ]
   ) sequence
-] func;
+] "mplBuiltinExportVariable" declareBuiltin ucall
 
-mplBuiltinImportFunction: [
+[
   (
     [compilable]
     [currentNode.parent 0 = not ["import must be global" compilerError] when]
@@ -992,9 +921,9 @@ mplBuiltinImportFunction: [
     [signature: parseSignature;]
     [index: signature VarString varName.data.get makeStringView FALSE dynamic processImportFunction;]
   ) sequence
-] func;
+] "mplBuiltinImportFunction" declareBuiltin ucall
 
-mplBuiltinCodeRef: [
+[
   (
     [compilable]
     [signature: parseSignature;]
@@ -1013,9 +942,9 @@ mplBuiltinCodeRef: [
       refToVar push
     ]
   ) sequence
-] func;
+] "mplBuiltinCodeRef" declareBuiltin ucall
 
-mplBuiltinImportVariable: [
+[
   currentNode.parent 0 = not ["import must be global" compilerError] when
   compilable [
     refToName: pop;
@@ -1056,9 +985,9 @@ mplBuiltinImportVariable: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinImportVariable" declareBuiltin ucall
 
-mplBuiltinCopy: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.temporary [
@@ -1079,9 +1008,9 @@ mplBuiltinCopy: [
       ] if
     ] if
   ] when
-] func;
+] "mplBuiltinCopy" declareBuiltin ucall
 
-mplBuiltinNewVarOfTheSameType: [
+[
   refToVar: pop;
   compilable [
     result: refToVar copyVarToNew;
@@ -1092,9 +1021,9 @@ mplBuiltinNewVarOfTheSameType: [
 
     result push
   ] when
-] func;
+] "mplBuiltinNewVarOfTheSameType" declareBuiltin ucall
 
-mplBuiltinCast: [
+[
   refToSchema: pop;
   refToVar: pop;
 
@@ -1185,9 +1114,9 @@ mplBuiltinCast: [
       "can cast only numbers" compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinCast" declareBuiltin ucall
 
-mplBuiltinStorageAddress: [
+[
   (
     [compilable]
     [refToVar: pop;]
@@ -1206,9 +1135,9 @@ mplBuiltinStorageAddress: [
       refToDst push
     ]
   ) sequence
-] func;
+] "mplBuiltinStorageAddress" declareBuiltin ucall
 
-mplBuiltinAddressToReference: [
+[
   refToSchema: pop;
   refToVar: pop;
 
@@ -1257,25 +1186,25 @@ mplBuiltinAddressToReference: [
       "address must be a NatX" compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinAddressToReference" declareBuiltin ucall
 
-mplBuiltinConstVar: [
+[
   currentNode.nextLabelIsConst ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsConst set
-] func;
+] "mplBuiltinConstVar" declareBuiltin ucall
 
-mplBuiltinVirtual: [
+[
   currentNode.nextLabelIsVirtual ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsVirtual set
-] func;
+] "mplBuiltinVirtual" declareBuiltin ucall
 
-mplBuiltinSchema: [
+[
   currentNode.nextLabelIsSchema ["duplicate schema specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsSchema set
-] func;
+] "mplBuiltinSchema" declareBuiltin ucall
 
-mplBuiltinModule: [
-  parentIndex 0 = not [
+[
+  currentNode.parent 0 = not [
     "module can be declared only in top node" makeStringView compilerError
   ] [
     refToName: pop;
@@ -1307,90 +1236,12 @@ mplBuiltinModule: [
       ] when
     ] when
   ] if
-] func;
+] "mplBuiltinModule" declareBuiltin ucall
 
-addNamesFromModule: [
-  copy moduleId:;
+[TRUE dynamic defaultUseOrIncludeModule] "mplBuiltinUseModule" declareBuiltin ucall
+[FALSE dynamic defaultUseOrIncludeModule] "mplBuiltinIncludeModule" declareBuiltin ucall
 
-  fru: current currentNode.usedOrIncludedModulesTable.find;
-  fru.success not [
-    moduleId TRUE @currentNode.@usedOrIncludedModulesTable.insert
-
-    moduleNode: moduleId processor.nodes.at.get;
-    moduleNode.labelNames [
-      current: .value;
-      current.nameInfo current.refToVar addOverloadForPre
-      current.nameInfo current.refToVar NameCaseFromModule addNameInfo #it is not own local variable
-    ] each
-  ] when
-] func;
-
-processUseModule: [
-  copy asUse:;
-  copy moduleId:;
-
-  currentModule: moduleId processor.nodes.at.get;
-  moduleList: currentModule.includedModules copy;
-  moduleId @moduleList.pushBack
-
-  moduleList [
-    pair:;
-    current: pair.value;
-    #("try include module with id " current " name " current processor.nodes.at.get.moduleName) addLog
-    last: pair.index moduleList.getSize 1 - =;
-
-    asUse [last copy] && [
-      current {used: FALSE dynamic; position: currentNode.position copy;} @currentNode.@usedModulesTable.insert
-      current TRUE @currentNode.@directlyIncludedModulesTable.insert
-      current addNamesFromModule
-    ] [
-      fr: current currentNode.includedModulesTable.find;
-      fr.success not [
-        last [
-          current TRUE @currentNode.@directlyIncludedModulesTable.insert
-        ] when
-        current @currentNode.@includedModules.pushBack
-        current {used: FALSE dynamic; position: currentNode.position copy;} @currentNode.@includedModulesTable.insert
-        current addNamesFromModule
-      ] when
-    ] if
-  ] each
-] func;
-
-mplBuiltinUseOrIncludeModule: [
-  copy asUse:;
-  (
-    [compilable]
-    [parentIndex 0 = not ["module can be used only in top node" compilerError] when]
-    [refToName: pop;]
-    [refToName staticnessOfVar Weak < ["name must be static string" compilerError] when]
-    [
-      varName: refToName getVar;
-      varName.data.getTag VarString = not ["name must be static string" compilerError] when
-    ] [
-      string: VarString varName.data.get;
-      fr: string makeStringView processor.modules.find;
-      fr.success [fr.value 0 < not] && [
-        frn: fr.value currentNode.usedModulesTable.find;
-        frn2: fr.value currentNode.directlyIncludedModulesTable.find;
-        frn.success frn2.success or [
-          ("duplicate use module: " string) assembleString compilerError
-        ] [
-          fr.value asUse processUseModule
-        ] if
-      ] [
-        TRUE dynamic @processorResult.@findModuleFail set
-        string @processorResult.@errorInfo.@missedModule set
-        ("module not found: " string) assembleString compilerError
-      ] if
-    ]
-  ) sequence
-] func;
-
-mplBuiltinUseModule: [TRUE dynamic mplBuiltinUseOrIncludeModule] func;
-mplBuiltinIncludeModule: [FALSE dynamic mplBuiltinUseOrIncludeModule] func;
-
-mplBuiltinTextSize: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < [
@@ -1407,9 +1258,9 @@ mplBuiltinTextSize: [
       ] when
     ] if
   ] when
-] func;
+] "mplBuiltinTextSize" declareBuiltin ucall
 
-mplBuiltinStrCat: [
+[
   (
     [compilable]
     [refToStr2: pop;]
@@ -1426,9 +1277,9 @@ mplBuiltinStrCat: [
     ]
     [(VarString varStr1.data.get VarString varStr2.data.get) assembleString VarString createVariable createStringIR push]
   ) sequence
-] func;
+] "mplBuiltinStrCat" declareBuiltin ucall
 
-mplBuiltinTextSplit: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < ["name must be static string" makeStringView compilerError] when
@@ -1488,9 +1339,9 @@ mplBuiltinTextSplit: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinTextSplit" declareBuiltin ucall
 
-mplBuiltinHas: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1514,9 +1365,9 @@ mplBuiltinHas: [
       ] if
     ]
   ) sequence
-] func;
+] "mplBuiltinHas" declareBuiltin ucall
 
-mplBuiltinFieldIndex: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1539,9 +1390,9 @@ mplBuiltinFieldIndex: [
       fr.index Int64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
     ]
   ) sequence
-] func;
+] "mplBuiltinFieldIndex" declareBuiltin ucall
 
-mplBuiltinDef: [
+[
   (
     [compilable]
     [refToName: pop;]
@@ -1556,9 +1407,9 @@ mplBuiltinDef: [
       VarString varName.data.get findNameInfo pop createNamedVariable
     ]
   ) sequence
-] func;
+] "mplBuiltinDef" declareBuiltin ucall
 
-mplBuiltinStorageSize: [
+[
   refToVar: pop;
   compilable [
     refToVar isVirtual [
@@ -1578,9 +1429,9 @@ mplBuiltinStorageSize: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinStorageSize" declareBuiltin ucall
 
-mplBuiltinAlignment: [
+[
   refToVar: pop;
   compilable [
     refToVar isVirtual [
@@ -1600,9 +1451,9 @@ mplBuiltinAlignment: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinAlignment" declareBuiltin ucall
 
-mplBuiltinPrintCompilerMessage: [
+[
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < ["name must be static string" makeStringView compilerError] when
@@ -1614,57 +1465,31 @@ mplBuiltinPrintCompilerMessage: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinPrintCompilerMessage" declareBuiltin ucall
 
-mplBuiltinPrintVariableCount: [
+[
   compilable [
     ("var count=" processor.varCount LF) printList
   ] when
-] func;
+] "mplBuiltinPrintVariableCount" declareBuiltin ucall
 
-mplBuiltinPrintStack: [
-  ("stack:" LF "depth=" getStackDepth LF) printList
+[
+  defaultPrintStack
+] "mplBuiltinPrintStack" declareBuiltin ucall
 
-  i: 0 dynamic;
-  [
-    i getStackDepth < [
-      entry: i getStackEntryUnchecked;
-      (i getStackEntryUnchecked getMplType entry.mutable ["R" makeStringView]["C" makeStringView] if LF) printList
-      i 1 + @i set TRUE
-    ] &&
-  ] loop
-] func;
+[
+  defaultPrintStackTrace
+] "mplBuiltinPrintStackTrace" declareBuiltin ucall
 
-mplBuiltinPrintStackTrace: [
-  nodeIndex: indexOfNode copy;
-  [
-    node: nodeIndex processor.nodes.at.get;
-    node.root [
-      FALSE
-    ] [
-      ("at filename: "  node.position.filename processor.options.fileNames.at
-        ", token: "      node.position.token
-        ", nodeIndex: "  nodeIndex
-        ", line: "       node.position.line
-        ", column: "     node.position.column LF) printList
-
-      node.parent @nodeIndex set
-      TRUE
-    ] if
-  ] loop
-
-  mplBuiltinPrintStack
-] func;
-
-mplBuiltinSame: [
+[
   refToVar1: pop;
   refToVar2: pop;
   compilable [
     refToVar1 refToVar2 variablesAreSame VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinSame" declareBuiltin ucall
 
-mplBuiltinIs: [
+[
   refToVar1: pop;
   refToVar2: pop;
   compilable [
@@ -1680,6 +1505,7 @@ mplBuiltinIs: [
           -1 @cmpResult set
         ] if
       ] if
+
       cmpResult 0 = [
         result: FALSE VarCond createVariable Dynamic makeStaticness createAllocIR;
         refToVar1 refToVar2 result "icmp eq" makeStringView createDirectBinaryOperation
@@ -1691,31 +1517,31 @@ mplBuiltinIs: [
       FALSE VarCond createVariable Static makeStaticness createPlainIR push
     ] if
   ] when
-] func;
+] "mplBuiltinIs" declareBuiltin ucall
 
-mplBuiltinIsConst: [
+[
   refToVar: pop;
   compilable [
     refToVar.mutable not VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsConst" declareBuiltin ucall
 
-mplBuiltinIsCombined: [
+[
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarStruct = VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsCombined" declareBuiltin ucall
 
-mplBuiltinDebug: [
+[
   processor.options.debug VarCond createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinDebug" declareBuiltin ucall
 
-mplBuiltinHasLogs: [
+[
   processor.options.logs VarCond createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinHasLogs" declareBuiltin ucall
 
-mplBuiltinFieldCount: [
+[
   refToVar: pop;
   compilable [
     var: refToVar getVar;
@@ -1733,9 +1559,9 @@ mplBuiltinFieldCount: [
       ] when
     ] if
   ] when
-] func;
+] "mplBuiltinFieldCount" declareBuiltin ucall
 
-mplBuiltinFieldName: [
+[
   refToCount: pop;
   refToVar: pop;
   compilable [
@@ -1766,13 +1592,13 @@ mplBuiltinFieldName: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinFieldName" declareBuiltin ucall
 
-mplBuiltinCompilerVersion: [
+[
   COMPILER_SOURCE_VERSION 0i64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
-] func;
+] "mplBuiltinCompilerVersion" declareBuiltin ucall
 
-mplBuiltinArray: [
+[
   refToCount: pop;
   refToElement: pop;
   compilable [
@@ -1833,21 +1659,21 @@ mplBuiltinArray: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinArray" declareBuiltin ucall
 
-mplBuiltinNew: [
+[
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createNew push mplBuiltinRef
-] func;
+  refToVar createNew push TRUE defaultRef
+] "mplBuiltinNew" declareBuiltin ucall
 
-mplBuiltinDelete: [
+[
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
   refToVar createDelete
-] func;
+] "mplBuiltinDelete" declareBuiltin ucall
 
-mplBuiltinMove: [
+[
   refToVar: pop;
   compilable [
     refToVar.mutable [
@@ -1865,9 +1691,9 @@ mplBuiltinMove: [
       "moved can be only mutable variables" makeStringView compilerError
     ] if
   ] when
-] func;
+] "mplBuiltinMove" declareBuiltin ucall
 
-mplBuiltinMoveIf: [
+[
   refToCond: pop;
   compilable [
     condVar: refToCond getVar;
@@ -1896,39 +1722,39 @@ mplBuiltinMoveIf: [
       ] when
     ] when
   ] when
-] func;
+] "mplBuiltinMoveIf" declareBuiltin ucall
 
-mplBuiltinIsMoved: [
+[
   refToVar: pop;
   compilable [
     refToVar push
     refToVar isForgotten
     VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] func;
+] "mplBuiltinIsMoved" declareBuiltin ucall
 
-mplBuiltinManuallyInitVariable: [
+[
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callInit] when
   ] when
-] func;
+] "mplBuiltinManuallyInitVariable" declareBuiltin ucall
 
-mplBuiltinManuallyDestroyVariable: [
+[
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callDie] when
   ] when
-] func;
+] "mplBuiltinManuallyDestroyVariable" declareBuiltin ucall
 
-mplBuiltinCompileOnce: [
+[
   TRUE dynamic @currentNode.@nodeCompileOnce set
-] func;
+] "mplBuiltinCompileOnce" declareBuiltin ucall
 
-mplBuiltinRecursive: [
+[
   TRUE dynamic @currentNode.@nodeIsRecursive set
-] func;
+] "mplBuiltinRecursive" declareBuiltin ucall
 
-mplBuiltinFailProc: [
-  text: pop;
-] func;
+[
+  defaultFailProc
+] "mplBuiltinFailProc" declareBuiltin ucall

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -635,15 +635,15 @@ mplBuiltinProcessAtList: [
                 ] when
 
                 refToIndex makeVarRealCaptured
-                fieldRef: 0 realStruct.fields.at.refToVar copy;
-                fieldRef.hostId indexOfNode = not [
+                firstField: 0 realStruct.fields.at.refToVar;
+                fieldRef: firstField copyVarFromParent;
+                firstField.hostId indexOfNode = not [
                   fBegin: RefToVar;
                   fEnd: RefToVar;
                   fieldRef @fBegin @fEnd ShadowReasonField makeShadowsDynamic
                   fEnd @fieldRef set
                 ] when
 
-                fieldRef copyVar @fieldRef set
                 refToStruct.mutable @fieldRef.@mutable set
                 fieldRef fullUntemporize
                 fieldRef staticnessOfVar Virtual = [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1662,18 +1662,6 @@ parseSignature: [
 ] "mplBuiltinArray" @declareBuiltin ucall
 
 [
-  TRUE dynamic @processor.@usedHeapBuiltins set
-  refToVar: pop;
-  compilable [refToVar createNew push TRUE defaultRef] when
-] "mplBuiltinNew" @declareBuiltin ucall
-
-[
-  TRUE dynamic @processor.@usedHeapBuiltins set
-  refToVar: pop;
-  compilable [refToVar createDelete] when
-] "mplBuiltinDelete" @declareBuiltin ucall
-
-[
   refToVar: pop;
   compilable [
     refToVar.mutable [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1292,8 +1292,7 @@ parseSignature: [
 
         fields: RefToVar Array;
 
-        string.chars.dataSize 0 > [
-
+        string.chars.dataSize 0 < not [
           splitted: string makeStringView.split;
           splitted.success [
             splitted.chars [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1149,7 +1149,7 @@ parseSignature: [
       varSchema: refToSchema getVar;
       varSchema.data.getTag VarString = [
         refToDst: String VarString createVariable;
-        Dynamic @refToDst getVar.@staticness set
+        Dirty @refToDst getVar.@staticness set
 
         refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
         refToDst push
@@ -1176,9 +1176,9 @@ parseSignature: [
             "pointee is virtual, cannot cast" compilerError
           ] [
             refToDst: schemaOfResult VarRef createVariable;
-            Dynamic refToDst getVar.@staticness set
+            Dirty refToDst getVar.@staticness set
             refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
-            refToDst derefAndPush
+            refToDst getPointee derefAndPush
           ] if
         ] if
       ] if

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -73,6 +73,8 @@ mplNumberBinaryOp: [
           ] when
         ] staticCall
       ] [
+        arg1 makeVarRealCaptured
+        arg2 makeVarRealCaptured
         opName: arg1 arg2 @getOpName call;
         var1.data.getTag firstTag lastTag [
           copy tag:;
@@ -157,6 +159,9 @@ mplNumberBinaryOp: [
           ] staticCall
         ] if
       ] [
+        arg1 makeVarRealCaptured
+        arg2 makeVarRealCaptured
+
         var1.data.getTag VarString = [
           result: FALSE VarCond createVariable Dynamic makeStaticness createAllocIR;
           "icmp eq" makeStringView createBinaryOperation
@@ -223,6 +228,7 @@ mplNumberUnaryOp: [
           ] when
         ] staticCall
       ] [
+        arg makeVarRealCaptured
         opName: arg @getOpName call;
         mopName: arg @getMidOpName call;
         var.data.getTag firstTag lastTag [
@@ -304,6 +310,7 @@ mplNumberBuiltinOp: [
           ] when
         ] staticCall
       ] [
+        arg makeVarRealCaptured
         opName: arg @getOpName call;
         var.data.getTag VarReal32 VarReal64 1 + [
           copy tag:;
@@ -408,6 +415,9 @@ mplNumberBuiltinOp: [
           ] when
         ] staticCall
       ] [
+        arg1 makeVarRealCaptured
+        arg2 makeVarRealCaptured
+
         var1.data.getTag VarReal32 VarReal64 1 + [
           copy tag:;
           resultType: tag copy;
@@ -473,6 +483,9 @@ mplShiftBinaryOp: [
           ] staticCall
         ] staticCall
       ] [
+        arg1 makeVarRealCaptured
+        arg2 makeVarRealCaptured
+
         opName: arg1 arg2 @getOpName call;
         var1.data.getTag VarNat8 VarIntX 1 + [
           copy tag:;
@@ -621,6 +634,7 @@ mplBuiltinProcessAtList: [
                   "can't get dynamic index in virtual struct" compilerError
                 ] when
 
+                refToIndex makeVarRealCaptured
                 fieldRef: 0 realStruct.fields.at.refToVar copy;
                 fieldRef.hostId indexOfNode = not [
                   fBegin: RefToVar;
@@ -994,6 +1008,8 @@ parseSignature: [
 [
   refToVar: pop;
   compilable [
+    refToVar isVirtual not [refToVar makeVarRealCaptured] when
+
     refToVar getVar.temporary [
       "temporary objects cannot be copied" compilerError
     ] [
@@ -1132,6 +1148,7 @@ parseSignature: [
     [refToVar isVirtual ["variable is virtual, cannot get address" compilerError] when]
     [
       TRUE refToVar getVar.@capturedAsMutable set #we need ref
+      refToVar makeVarRealCaptured
       refToVar makeVarTreeDirty
       refToDst: 0n64 VarNatX createVariable;
       Dynamic @refToDst getVar.@staticness set

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1664,13 +1664,13 @@ parseSignature: [
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createNew push TRUE defaultRef
+  compilable [refToVar createNew push TRUE defaultRef] when
 ] "mplBuiltinNew" declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
-  refToVar createDelete
+  compilable [refToVar createDelete] when
 ] "mplBuiltinDelete" declareBuiltin ucall
 
 [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -31,7 +31,7 @@ staticnessOfBinResult: [
       Static
     ] if
   ] if
-] func;
+];
 
 mplNumberBinaryOp: [
   exValidator:;
@@ -88,7 +88,7 @@ mplNumberBinaryOp: [
       ] if
     ] when
   ] when
-] func;
+];
 
 [
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fadd" makeStringView]["add" makeStringView] if] [+] [copy] [y:; x:;] mplNumberBinaryOp
@@ -124,7 +124,7 @@ mplNumberBinaryOp: [
     comparable: [
       arg:;
       arg isPlain [arg getVar.data.getTag VarString =] ||
-    ] func;
+    ];
 
     var1: arg1 getVar;
     var2: arg2 getVar;
@@ -238,7 +238,7 @@ mplNumberUnaryOp: [
       ] if
     ] when
   ] when
-] func;
+];
 
 [
   VarCond VarNatX 1 + [a:; "xor" makeStringView] [
@@ -330,7 +330,7 @@ mplNumberBuiltinOp: [
       ] if
     ] when
   ] when
-] func;
+];
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
@@ -491,7 +491,7 @@ mplShiftBinaryOp: [
       ] if
     ] when
   ] when
-] func;
+];
 
 [
   [t2:; t1:; "shl" makeStringView][lshift] mplShiftBinaryOp
@@ -660,7 +660,7 @@ mplBuiltinProcessAtList: [
   ] when
 
   result
-] func;
+];
 
 [
   field: mplBuiltinProcessAtList;
@@ -767,7 +767,7 @@ parseFieldToSignatureCaptureArray: [
   ] when
 
   result
-] func;
+];
 
 parseSignature: [
   result: CFunctionSignature;
@@ -839,7 +839,7 @@ parseSignature: [
     ]
   ) sequence
   result
-] func;
+];
 
 [
   (

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -885,24 +885,24 @@ parseSignature: [
     ]
     [
       hasConvention not [
-        "default convention is not implemented" compilerError
-      ] [
-        return: pop;
-        compilable [
-          return isVirtual [
-            returnVar: return getVar;
-            returnVar.data.getTag VarStruct = not [(return getMplType " can not be a return type") assembleString compilerError] when
+        String @result.@convention set
+      ] when
+
+      return: pop;
+      compilable [
+        return isVirtual [
+          returnVar: return getVar;
+          returnVar.data.getTag VarStruct = not [(return getMplType " can not be a return type") assembleString compilerError] when
+        ] [
+          #todo: detect temporality
+          returnVar: return getVar;
+          returnVar.temporary [
+            return @result.@outputs.pushBack
           ] [
-            #todo: detect temporality
-            returnVar: return getVar;
-            returnVar.temporary [
-              return @result.@outputs.pushBack
-            ] [
-              return return.mutable createRef @result.@outputs.pushBack
-            ] if
+            return return.mutable createRef @result.@outputs.pushBack
           ] if
-        ] when
-      ] if
+        ] if
+      ] when
     ]
     [arguments: pop;]
     [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -543,7 +543,7 @@ mplShiftBinaryOp: [
   compilable [
     varCode: code getVar;
 
-    varCode.data.getTag VarCode = not ["branch else must be a [CODE]" makeStringView compilerError] when
+    varCode.data.getTag VarCode = not ["branch else must be a [CODE]" compilerError] when
 
     compilable [
       codeIndex: VarCode varCode.data.get.index copy;

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1028,11 +1028,16 @@ parseSignature: [
   refToVar: pop;
 
   compilable [
+    varSrc: refToVar getVar;
+    varSchema: refToSchema getVar;
+    varSchema.data.getTag VarRef = [refToSchema isVirtual] && [
+      VarRef varSchema.data.get copyVarFromChild @refToSchema set
+      refToSchema getVar !varSchema
+    ] when
+
     refToVar isNumber refToSchema isNumber and [
       compilable [
         refToVar staticnessOfVar Dynamic > [
-          varSrc: refToVar getVar;
-          varSchema: refToSchema getVar;
           refToDst: RefToVar;
 
           varSrc.data.getTag VarNat8 VarReal64 1 + [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -849,7 +849,7 @@ parseSignature: [
     [refToName staticnessOfVar Weak < ["function name must be static string" compilerError] when]
     [
       varName: refToName getVar;
-      varName.data.getTag VarString = not ["name must be static string" compilerError] when
+      varName.data.getTag VarString = not ["function name must be static string" compilerError] when
     ]
     [refToBody: pop;]
     [
@@ -870,10 +870,10 @@ parseSignature: [
     [currentNode.parent 0 = not ["export must be global" compilerError] when]
     [refToName: pop;]
     [refToVar: pop;]
-    [refToName staticnessOfVar Weak < ["function name must be static string" compilerError] when]
+    [refToName staticnessOfVar Weak < ["variable name must be static string" compilerError] when]
     [
       varName: refToName getVar;
-      varName.data.getTag VarString = not ["name must be static string" compilerError] when
+      varName.data.getTag VarString = not ["variable name must be static string" compilerError] when
     ] [
       refToVar isVirtual ["cannot export virtual var" compilerError] when
     ] [
@@ -916,7 +916,7 @@ parseSignature: [
     [refToName staticnessOfVar Weak < ["function name must be static string" compilerError] when]
     [
       varName: refToName getVar;
-      varName.data.getTag VarString = not ["name must be static string" compilerError] when
+      varName.data.getTag VarString = not ["function name must be static string" compilerError] when
     ]
     [signature: parseSignature;]
     [index: signature VarString varName.data.get makeStringView FALSE dynamic processImportFunction;]

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -950,12 +950,10 @@ parseSignature: [
       index: signature name makeStringView TRUE dynamic processImportFunction;
     ]
     [
-      #refToVar: index processor.nodes.at.get.refToVar;
       nullNode: index processor.nodes.at.get;
       gnr: nullNode.varNameInfo getName;
       cnr: gnr captureName;
       refToVar: cnr.refToVar copy;
-      #("coderef captured var=" refToVar.hostId ":" refToVar.varId " s=" refToVar staticnessOfVar) addLog
 
       refToVar push
     ]
@@ -1271,7 +1269,6 @@ parseSignature: [
   refToName: pop;
   compilable [
     refToName staticnessOfVar Weak < [
-      #"name must be static" compilerError
       result: 0n64 VarNatX createVariable Dynamic makeStaticness createAllocIR;
       refToName result createGetTextSizeIR
       result push

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -533,7 +533,7 @@ mplShiftBinaryOp: [
     varCode.data.getTag VarCode = not ["branch else must be a [CODE]" makeStringView compilerError] when
 
     compilable [
-      codeIndex: VarCode varCode.data.get copy;
+      codeIndex: VarCode varCode.data.get.index copy;
       astNode: codeIndex @multiParserResult.@memory.at;
       [astNode.data.getTag AstNodeType.Code =] "Not a code!" assert
       indexArray: AstNodeType.Code astNode.data.get;
@@ -694,14 +694,14 @@ mplBuiltinProcessAtList: [
       condition staticnessOfVar Weak > [
         value: VarCond varCond.data.get copy;
         value [
-          VarCode varThen.data.get "staticIfThen" makeStringView processCall
+          VarCode varThen.data.get.index "staticIfThen" makeStringView processCall
         ] [
-          VarCode varElse.data.get "staticIfElse" makeStringView processCall
+          VarCode varElse.data.get.index "staticIfElse" makeStringView processCall
         ] if
       ] [
         condition
-        VarCode varThen.data.get @multiParserResult.@memory.at
-        VarCode varElse.data.get @multiParserResult.@memory.at
+        VarCode varThen.data.get.index @multiParserResult.@memory.at
+        VarCode varElse.data.get.index @multiParserResult.@memory.at
         processIf
       ] if
     ] when
@@ -725,7 +725,7 @@ mplBuiltinProcessAtList: [
     compilable [
       condition staticnessOfVar Weak > [
         value: VarCond varCond.data.get copy;
-        codeIndex: value [VarCode varThen.data.get copy] [VarCode varElse.data.get copy] if;
+        codeIndex: value [VarCode varThen.data.get.index copy] [VarCode varElse.data.get.index copy] if;
         astNode: codeIndex @multiParserResult.@memory.at;
         [astNode.data.getTag AstNodeType.Code =] "Not a code!" assert
         indexArray: AstNodeType.Code astNode.data.get;
@@ -746,7 +746,7 @@ mplBuiltinProcessAtList: [
       varBody: body getVar;
       varBody.data.getTag VarCode = not ["body must be [CODE]" compilerError] when
     ] [
-      astNode: VarCode varBody.data.get @multiParserResult.@memory.at;
+      astNode: VarCode varBody.data.get.index @multiParserResult.@memory.at;
       astNode processLoop
     ]
   ) sequence
@@ -858,7 +858,7 @@ parseSignature: [
     ]
     [signature: parseSignature;]
     [
-      astNode: VarCode varBody.data.get @multiParserResult.@memory.at;
+      astNode: VarCode varBody.data.get.index @multiParserResult.@memory.at;
       index: signature astNode VarString varName.data.get makeStringView FALSE dynamic processExportFunction;
     ]
   ) sequence

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -92,29 +92,29 @@ mplNumberBinaryOp: [
 
 [
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fadd" makeStringView]["add" makeStringView] if] [+] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinAdd" declareBuiltin ucall
+] "mplBuiltinAdd" @declareBuiltin ucall
 
 [
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fsub" makeStringView]["sub" makeStringView] if] [-] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinSub" declareBuiltin ucall
+] "mplBuiltinSub" @declareBuiltin ucall
 
 [
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fmul" makeStringView]["mul" makeStringView] if] [*] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinMul" declareBuiltin ucall
+] "mplBuiltinMul" @declareBuiltin ucall
 
 [
   VarNat8 VarReal64 1 + [a2:; a1:; a2 isReal ["fdiv" makeStringView][a2 isNat ["udiv" makeStringView] ["sdiv" makeStringView] if] if] [/] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] "mplBuiltinDiv" declareBuiltin ucall
+] "mplBuiltinDiv" @declareBuiltin ucall
 
 [
   VarNat8 VarIntX 1 + [a2:; a1:; a2 isNat ["urem" makeStringView] ["srem" makeStringView] if] [mod] [copy] [
     y:; x:;
     y y - y = ["division by zero" compilerError] when
   ] mplNumberBinaryOp
-] "mplBuiltinMod" declareBuiltin ucall
+] "mplBuiltinMod" @declareBuiltin ucall
 
 [
   arg2: pop;
@@ -181,19 +181,19 @@ mplNumberBinaryOp: [
       ] if
     ] when
   ] when
-] "mplBuiltinEqual" declareBuiltin ucall
+] "mplBuiltinEqual" @declareBuiltin ucall
 
 [
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp olt" makeStringView][a2 isNat ["icmp ult" makeStringView] ["icmp slt" makeStringView] if] if
   ] [<] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinLess" declareBuiltin ucall
+] "mplBuiltinLess" @declareBuiltin ucall
 
 [
   VarNat8 VarReal64 1 + [
     a2:; a1:; a2 isReal ["fcmp ogt" makeStringView][a2 isNat ["icmp ugt" makeStringView] ["icmp sgt" makeStringView] if] if
   ] [>] [t:; VarCond] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinGreater" declareBuiltin ucall
+] "mplBuiltinGreater" @declareBuiltin ucall
 
 mplNumberUnaryOp: [
   exValidator:;
@@ -244,32 +244,32 @@ mplNumberUnaryOp: [
   VarCond VarNatX 1 + [a:; "xor" makeStringView] [
     a:; a getVar.data.getTag VarCond = ["true, " makeStringView]["-1, " makeStringView] if
   ] [not] [x:;] mplNumberUnaryOp
-] "mplBuiltinNot" declareBuiltin ucall
+] "mplBuiltinNot" @declareBuiltin ucall
 
 [
   VarCond VarNatX 1 + [a2:; a1:; "xor" makeStringView] [xor] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinXor" declareBuiltin ucall
+] "mplBuiltinXor" @declareBuiltin ucall
 
 [
   VarCond VarNatX 1 + [a2:; a1:; "and" makeStringView] [and] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinAnd" declareBuiltin ucall
+] "mplBuiltinAnd" @declareBuiltin ucall
 
 [
   VarCond VarNatX 1 + [a2:; a1:; "or" makeStringView] [or] [copy] [y:; x:;] mplNumberBinaryOp
-] "mplBuiltinOr" declareBuiltin ucall
+] "mplBuiltinOr" @declareBuiltin ucall
 
 [
   TRUE VarCond createVariable createPlainIR push
-] "mplBuiltinTrue" declareBuiltin ucall
+] "mplBuiltinTrue" @declareBuiltin ucall
 
 [
   FALSE VarCond createVariable createPlainIR push
-] "mplBuiltinFalse" declareBuiltin ucall
+] "mplBuiltinFalse" @declareBuiltin ucall
 
 [
   s: LF toString;
   s VarString createVariable createStringIR push
-] "mplBuiltinLF" declareBuiltin ucall
+] "mplBuiltinLF" @declareBuiltin ucall
 
 [
   VarInt8 VarReal64 1 + [
@@ -277,7 +277,7 @@ mplNumberUnaryOp: [
   ] [
     a:; a isAnyInt ["0, " makeStringView]["0x0000000000000000, " makeStringView] if
   ] [neg] [x:;] mplNumberUnaryOp
-] "mplBuiltinNeg" declareBuiltin ucall
+] "mplBuiltinNeg" @declareBuiltin ucall
 
 mplNumberBuiltinOp: [
   exValidator:;
@@ -336,43 +336,43 @@ mplNumberBuiltinOp: [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sin.f32" makeStringView]["@llvm.sin.f64" makeStringView] if
   ] [sin] [x:;] mplNumberBuiltinOp
-] "mplBuiltinSin" declareBuiltin ucall
+] "mplBuiltinSin" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.cos.f32" makeStringView]["@llvm.cos.f64" makeStringView] if
   ] [cos] [x:;] mplNumberBuiltinOp
-] "mplBuiltinCos" declareBuiltin ucall
+] "mplBuiltinCos" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.sqrt.f32" makeStringView]["@llvm.sqrt.f64" makeStringView] if
   ] [sqrt] [x:;] mplNumberBuiltinOp
-] "mplBuiltinSqrt" declareBuiltin ucall
+] "mplBuiltinSqrt" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.ceil.f32" makeStringView]["@llvm.ceil.f64" makeStringView] if
   ] [ceil] [x:;] mplNumberBuiltinOp
-] "mplBuiltinCeil" declareBuiltin ucall
+] "mplBuiltinCeil" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.floor.f32" makeStringView]["@llvm.floor.f64" makeStringView] if
   ] [floor] [x:;] mplNumberBuiltinOp
-] "mplBuiltinFloor" declareBuiltin ucall
+] "mplBuiltinFloor" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log.f32" makeStringView]["@llvm.log.f64" makeStringView] if
   ] [log] [x:;] mplNumberBuiltinOp
-] "mplBuiltinLog" declareBuiltin ucall
+] "mplBuiltinLog" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
   [a:; a getVar.data.getTag VarReal32 = ["@llvm.log10.f32" makeStringView]["@llvm.log10.f64" makeStringView] if
   ] [log10] [x:;] mplNumberBuiltinOp
-] "mplBuiltinLog10" declareBuiltin ucall
+] "mplBuiltinLog10" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedFloatBuiltins set
@@ -435,7 +435,7 @@ mplNumberBuiltinOp: [
       ] if
     ] when
   ] when
-] "mplBuiltinPow" declareBuiltin ucall
+] "mplBuiltinPow" @declareBuiltin ucall
 
 mplShiftBinaryOp: [
   opFunc:;
@@ -495,15 +495,15 @@ mplShiftBinaryOp: [
 
 [
   [t2:; t1:; "shl" makeStringView][lshift] mplShiftBinaryOp
-] "mplBuiltinLShift" declareBuiltin ucall
+] "mplBuiltinLShift" @declareBuiltin ucall
 
 [
   [t2:; t1:; t1 isNat ["lshr" makeStringView]["ashr" makeStringView] if][rshift] mplShiftBinaryOp
-] "mplBuiltinRShift" declareBuiltin ucall
+] "mplBuiltinRShift" @declareBuiltin ucall
 
-[TRUE defaultRef] "mplBuiltinRef" declareBuiltin ucall
-[FALSE defaultRef] "mplBuiltinCref" declareBuiltin ucall
-[TRUE defaultMakeConstWith] "mplBuiltinConst" declareBuiltin ucall
+[TRUE defaultRef] "mplBuiltinRef" @declareBuiltin ucall
+[FALSE defaultRef] "mplBuiltinCref" @declareBuiltin ucall
+[TRUE defaultMakeConstWith] "mplBuiltinConst" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -518,11 +518,11 @@ mplShiftBinaryOp: [
       "not a reference" makeStringView compilerError
     ] if
   ] when
-] "mplBuiltinDeref" declareBuiltin ucall
+] "mplBuiltinDeref" @declareBuiltin ucall
 
 [
   defaultCall
-] "mplBuiltinCall" declareBuiltin ucall
+] "mplBuiltinCall" @declareBuiltin ucall
 
 [
   code: pop;
@@ -540,7 +540,7 @@ mplShiftBinaryOp: [
       indexArray addIndexArrayToProcess
     ] when
   ] when
-] "mplBuiltinUcall" declareBuiltin ucall
+] "mplBuiltinUcall" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -548,7 +548,7 @@ mplShiftBinaryOp: [
     refToVar makeVarTreeDynamic
     refToVar push
   ] when
-] "mplBuiltinDynamic" declareBuiltin ucall
+] "mplBuiltinDynamic" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -556,7 +556,7 @@ mplShiftBinaryOp: [
     refToVar makeVarTreeDirty
     refToVar push
   ] when
-] "mplBuiltinDirty" declareBuiltin ucall
+] "mplBuiltinDirty" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -564,9 +564,9 @@ mplShiftBinaryOp: [
     refToVar staticnessOfVar Weak = [refToVar Static makeStaticness @refToVar set] when
     refToVar push
   ] when
-] "mplBuiltinStatic" declareBuiltin ucall
+] "mplBuiltinStatic" @declareBuiltin ucall
 
-[defaultSet] "mplBuiltinSet" declareBuiltin ucall
+[defaultSet] "mplBuiltinSet" @declareBuiltin ucall
 
 mplBuiltinProcessAtList: [
   refToStruct: pop;
@@ -667,14 +667,14 @@ mplBuiltinProcessAtList: [
   compilable [
     field derefAndPush
   ] when
-] "mplBuiltinAt" declareBuiltin ucall
+] "mplBuiltinAt" @declareBuiltin ucall
 
 [
   field: mplBuiltinProcessAtList;
   compilable [
     field setRef
   ] when
-] "mplBuiltinExclamation" declareBuiltin ucall
+] "mplBuiltinExclamation" @declareBuiltin ucall
 
 [
   else: pop;
@@ -706,7 +706,7 @@ mplBuiltinProcessAtList: [
       ] if
     ] when
   ] when
-] "mplBuiltinIf" declareBuiltin ucall
+] "mplBuiltinIf" @declareBuiltin ucall
 
 [
   else: pop;
@@ -735,7 +735,7 @@ mplBuiltinProcessAtList: [
       ] if
     ] when
   ] when
-] "mplBuiltinUif" declareBuiltin ucall
+] "mplBuiltinUif" @declareBuiltin ucall
 
 [
   body: pop;
@@ -750,7 +750,7 @@ mplBuiltinProcessAtList: [
       astNode processLoop
     ]
   ) sequence
-] "mplBuiltinLoop" declareBuiltin ucall
+] "mplBuiltinLoop" @declareBuiltin ucall
 
 parseFieldToSignatureCaptureArray: [
   refToStruct:;
@@ -862,7 +862,7 @@ parseSignature: [
       index: signature astNode VarString varName.data.get makeStringView FALSE dynamic processExportFunction;
     ]
   ) sequence
-] "mplBuiltinExportFunction" declareBuiltin ucall
+] "mplBuiltinExportFunction" @declareBuiltin ucall
 
 [
   (
@@ -906,7 +906,7 @@ parseSignature: [
       ] when
     ]
   ) sequence
-] "mplBuiltinExportVariable" declareBuiltin ucall
+] "mplBuiltinExportVariable" @declareBuiltin ucall
 
 [
   (
@@ -921,7 +921,7 @@ parseSignature: [
     [signature: parseSignature;]
     [index: signature VarString varName.data.get makeStringView FALSE dynamic processImportFunction;]
   ) sequence
-] "mplBuiltinImportFunction" declareBuiltin ucall
+] "mplBuiltinImportFunction" @declareBuiltin ucall
 
 [
   (
@@ -942,7 +942,7 @@ parseSignature: [
       refToVar push
     ]
   ) sequence
-] "mplBuiltinCodeRef" declareBuiltin ucall
+] "mplBuiltinCodeRef" @declareBuiltin ucall
 
 [
   currentNode.parent 0 = not ["import must be global" compilerError] when
@@ -985,7 +985,7 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinImportVariable" declareBuiltin ucall
+] "mplBuiltinImportVariable" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1008,7 +1008,7 @@ parseSignature: [
       ] if
     ] if
   ] when
-] "mplBuiltinCopy" declareBuiltin ucall
+] "mplBuiltinCopy" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1021,7 +1021,7 @@ parseSignature: [
 
     result push
   ] when
-] "mplBuiltinNewVarOfTheSameType" declareBuiltin ucall
+] "mplBuiltinNewVarOfTheSameType" @declareBuiltin ucall
 
 [
   refToSchema: pop;
@@ -1114,7 +1114,7 @@ parseSignature: [
       "can cast only numbers" compilerError
     ] if
   ] when
-] "mplBuiltinCast" declareBuiltin ucall
+] "mplBuiltinCast" @declareBuiltin ucall
 
 [
   (
@@ -1135,7 +1135,7 @@ parseSignature: [
       refToDst push
     ]
   ) sequence
-] "mplBuiltinStorageAddress" declareBuiltin ucall
+] "mplBuiltinStorageAddress" @declareBuiltin ucall
 
 [
   refToSchema: pop;
@@ -1186,22 +1186,22 @@ parseSignature: [
       "address must be a NatX" compilerError
     ] if
   ] when
-] "mplBuiltinAddressToReference" declareBuiltin ucall
+] "mplBuiltinAddressToReference" @declareBuiltin ucall
 
 [
   currentNode.nextLabelIsConst ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsConst set
-] "mplBuiltinConstVar" declareBuiltin ucall
+] "mplBuiltinConstVar" @declareBuiltin ucall
 
 [
   currentNode.nextLabelIsVirtual ["duplicate virtual specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsVirtual set
-] "mplBuiltinVirtual" declareBuiltin ucall
+] "mplBuiltinVirtual" @declareBuiltin ucall
 
 [
   currentNode.nextLabelIsSchema ["duplicate schema specifier" compilerError] when
   TRUE @currentNode.@nextLabelIsSchema set
-] "mplBuiltinSchema" declareBuiltin ucall
+] "mplBuiltinSchema" @declareBuiltin ucall
 
 [
   currentNode.parent 0 = not [
@@ -1236,10 +1236,10 @@ parseSignature: [
       ] when
     ] when
   ] if
-] "mplBuiltinModule" declareBuiltin ucall
+] "mplBuiltinModule" @declareBuiltin ucall
 
-[TRUE dynamic defaultUseOrIncludeModule] "mplBuiltinUseModule" declareBuiltin ucall
-[FALSE dynamic defaultUseOrIncludeModule] "mplBuiltinIncludeModule" declareBuiltin ucall
+[TRUE dynamic defaultUseOrIncludeModule] "mplBuiltinUseModule" @declareBuiltin ucall
+[FALSE dynamic defaultUseOrIncludeModule] "mplBuiltinIncludeModule" @declareBuiltin ucall
 
 [
   refToName: pop;
@@ -1258,7 +1258,7 @@ parseSignature: [
       ] when
     ] if
   ] when
-] "mplBuiltinTextSize" declareBuiltin ucall
+] "mplBuiltinTextSize" @declareBuiltin ucall
 
 [
   (
@@ -1277,7 +1277,7 @@ parseSignature: [
     ]
     [(VarString varStr1.data.get VarString varStr2.data.get) assembleString VarString createVariable createStringIR push]
   ) sequence
-] "mplBuiltinStrCat" declareBuiltin ucall
+] "mplBuiltinStrCat" @declareBuiltin ucall
 
 [
   refToName: pop;
@@ -1339,7 +1339,7 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinTextSplit" declareBuiltin ucall
+] "mplBuiltinTextSplit" @declareBuiltin ucall
 
 [
   (
@@ -1365,7 +1365,7 @@ parseSignature: [
       ] if
     ]
   ) sequence
-] "mplBuiltinHas" declareBuiltin ucall
+] "mplBuiltinHas" @declareBuiltin ucall
 
 [
   (
@@ -1390,7 +1390,7 @@ parseSignature: [
       fr.index Int64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
     ]
   ) sequence
-] "mplBuiltinFieldIndex" declareBuiltin ucall
+] "mplBuiltinFieldIndex" @declareBuiltin ucall
 
 [
   (
@@ -1407,7 +1407,7 @@ parseSignature: [
       VarString varName.data.get findNameInfo pop createNamedVariable
     ]
   ) sequence
-] "mplBuiltinDef" declareBuiltin ucall
+] "mplBuiltinDef" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1429,7 +1429,7 @@ parseSignature: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinStorageSize" declareBuiltin ucall
+] "mplBuiltinStorageSize" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1451,7 +1451,7 @@ parseSignature: [
 
     0n64 cast VarNatX createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinAlignment" declareBuiltin ucall
+] "mplBuiltinAlignment" @declareBuiltin ucall
 
 [
   refToName: pop;
@@ -1465,21 +1465,21 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinPrintCompilerMessage" declareBuiltin ucall
+] "mplBuiltinPrintCompilerMessage" @declareBuiltin ucall
 
 [
   compilable [
     ("var count=" processor.varCount LF) printList
   ] when
-] "mplBuiltinPrintVariableCount" declareBuiltin ucall
+] "mplBuiltinPrintVariableCount" @declareBuiltin ucall
 
 [
   defaultPrintStack
-] "mplBuiltinPrintStack" declareBuiltin ucall
+] "mplBuiltinPrintStack" @declareBuiltin ucall
 
 [
   defaultPrintStackTrace
-] "mplBuiltinPrintStackTrace" declareBuiltin ucall
+] "mplBuiltinPrintStackTrace" @declareBuiltin ucall
 
 [
   refToVar1: pop;
@@ -1487,7 +1487,7 @@ parseSignature: [
   compilable [
     refToVar1 refToVar2 variablesAreSame VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinSame" declareBuiltin ucall
+] "mplBuiltinSame" @declareBuiltin ucall
 
 [
   refToVar1: pop;
@@ -1517,29 +1517,29 @@ parseSignature: [
       FALSE VarCond createVariable Static makeStaticness createPlainIR push
     ] if
   ] when
-] "mplBuiltinIs" declareBuiltin ucall
+] "mplBuiltinIs" @declareBuiltin ucall
 
 [
   refToVar: pop;
   compilable [
     refToVar.mutable not VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinIsConst" declareBuiltin ucall
+] "mplBuiltinIsConst" @declareBuiltin ucall
 
 [
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarStruct = VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinIsCombined" declareBuiltin ucall
+] "mplBuiltinIsCombined" @declareBuiltin ucall
 
 [
   processor.options.debug VarCond createVariable Static makeStaticness createPlainIR push
-] "mplBuiltinDebug" declareBuiltin ucall
+] "mplBuiltinDebug" @declareBuiltin ucall
 
 [
   processor.options.logs VarCond createVariable Static makeStaticness createPlainIR push
-] "mplBuiltinHasLogs" declareBuiltin ucall
+] "mplBuiltinHasLogs" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1559,7 +1559,7 @@ parseSignature: [
       ] when
     ] if
   ] when
-] "mplBuiltinFieldCount" declareBuiltin ucall
+] "mplBuiltinFieldCount" @declareBuiltin ucall
 
 [
   refToCount: pop;
@@ -1592,11 +1592,11 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinFieldName" declareBuiltin ucall
+] "mplBuiltinFieldName" @declareBuiltin ucall
 
 [
   COMPILER_SOURCE_VERSION 0i64 cast VarInt32 createVariable Static makeStaticness createPlainIR push
-] "mplBuiltinCompilerVersion" declareBuiltin ucall
+] "mplBuiltinCompilerVersion" @declareBuiltin ucall
 
 [
   refToCount: pop;
@@ -1659,19 +1659,19 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinArray" declareBuiltin ucall
+] "mplBuiltinArray" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
   compilable [refToVar createNew push TRUE defaultRef] when
-] "mplBuiltinNew" declareBuiltin ucall
+] "mplBuiltinNew" @declareBuiltin ucall
 
 [
   TRUE dynamic @processor.@usedHeapBuiltins set
   refToVar: pop;
   compilable [refToVar createDelete] when
-] "mplBuiltinDelete" declareBuiltin ucall
+] "mplBuiltinDelete" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1691,7 +1691,7 @@ parseSignature: [
       "moved can be only mutable variables" makeStringView compilerError
     ] if
   ] when
-] "mplBuiltinMove" declareBuiltin ucall
+] "mplBuiltinMove" @declareBuiltin ucall
 
 [
   refToCond: pop;
@@ -1722,7 +1722,7 @@ parseSignature: [
       ] when
     ] when
   ] when
-] "mplBuiltinMoveIf" declareBuiltin ucall
+] "mplBuiltinMoveIf" @declareBuiltin ucall
 
 [
   refToVar: pop;
@@ -1731,30 +1731,30 @@ parseSignature: [
     refToVar isForgotten
     VarCond createVariable Static makeStaticness createPlainIR push
   ] when
-] "mplBuiltinIsMoved" declareBuiltin ucall
+] "mplBuiltinIsMoved" @declareBuiltin ucall
 
 [
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callInit] when
   ] when
-] "mplBuiltinManuallyInitVariable" declareBuiltin ucall
+] "mplBuiltinManuallyInitVariable" @declareBuiltin ucall
 
 [
   refToVar: pop;
   compilable [
     refToVar isAutoStruct [refToVar callDie] when
   ] when
-] "mplBuiltinManuallyDestroyVariable" declareBuiltin ucall
+] "mplBuiltinManuallyDestroyVariable" @declareBuiltin ucall
 
 [
   TRUE dynamic @currentNode.@nodeCompileOnce set
-] "mplBuiltinCompileOnce" declareBuiltin ucall
+] "mplBuiltinCompileOnce" @declareBuiltin ucall
 
 [
   TRUE dynamic @currentNode.@nodeIsRecursive set
-] "mplBuiltinRecursive" declareBuiltin ucall
+] "mplBuiltinRecursive" @declareBuiltin ucall
 
 [
   defaultFailProc
-] "mplBuiltinFailProc" declareBuiltin ucall
+] "mplBuiltinFailProc" @declareBuiltin ucall

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -536,6 +536,8 @@ mplShiftBinaryOp: [
       codeIndex: VarCode varCode.data.get.index copy;
       astNode: codeIndex @multiParserResult.@memory.at;
       [astNode.data.getTag AstNodeType.Code =] "Not a code!" assert
+      currentNode.countOfUCall 1 + @currentNode.@countOfUCall set
+      currentNode.countOfUCall 65535 > ["ucall limit exceeded" compilerError] when
       indexArray: AstNodeType.Code astNode.data.get;
       indexArray addIndexArrayToProcess
     ] when
@@ -728,6 +730,8 @@ mplBuiltinProcessAtList: [
         codeIndex: value [VarCode varThen.data.get.index copy] [VarCode varElse.data.get.index copy] if;
         astNode: codeIndex @multiParserResult.@memory.at;
         [astNode.data.getTag AstNodeType.Code =] "Not a code!" assert
+        currentNode.countOfUCall 1 + @currentNode.@countOfUCall set
+        currentNode.countOfUCall 65535 > ["ucall limit exceeded" compilerError] when
         indexArray: AstNodeType.Code astNode.data.get;
         indexArray addIndexArrayToProcess
       ] [

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -588,7 +588,7 @@ mplBuiltinProcessAtList: [
           pointeeVar: pointee getVar;
           pointeeVar.data.getTag VarStruct = not ["not a combined" compilerError] when
         ]
-        [ indexVar.data.getTag VarInt32 = not ["index must be Int32" compilerError] when ]
+        [indexVar.data.getTag VarInt32 = not ["index must be Int32" compilerError] when ]
         [refToIndex staticnessOfVar Weak < [ "index must be static" compilerError] when ]
         [
           index: VarInt32 indexVar.data.get 0 cast;

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -6,8 +6,8 @@
 "defaultImpl" includeModule
 
 declareBuiltin: [
-  declareBuiltinName:;
-  declareBuiltinBody:;
+  virtual declareBuiltinName:;
+  virtual declareBuiltinBody:;
 
   {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;} () {} [
     processorResult:;

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -26,15 +26,12 @@ builtins: (
   {name: "ceil"                    ; impl: @mplBuiltinCeil                    ;}
   {name: "codeRef"                 ; impl: @mplBuiltinCodeRef                 ;}
   {name: "cos"                     ; impl: @mplBuiltinCos                     ;}
-  #{name: "cref"                    ; impl: @mplBuiltinCref                    ;}
   {name: "compileOnce"             ; impl: @mplBuiltinCompileOnce             ;}
   {name: "COMPILER_VERSION"        ; impl: @mplBuiltinCompilerVersion         ;}
   {name: "const"                   ; impl: @mplBuiltinConst                   ;}
   {name: "copy"                    ; impl: @mplBuiltinCopy                    ;}
   {name: "DEBUG"                   ; impl: @mplBuiltinDebug                   ;}
   {name: "def"                     ; impl: @mplBuiltinDef                     ;}
-  #{name: "deref"                   ; impl: @mplBuiltinDeref                   ;}
-  #{name: "dirty"                   ; impl: @mplBuiltinDirty                   ;}
   {name: "dynamic"                 ; impl: @mplBuiltinDirty                   ;}
   {name: "exportFunction"          ; impl: @mplBuiltinExportFunction          ;}
   {name: "exportVariable"          ; impl: @mplBuiltinExportVariable          ;}
@@ -74,7 +71,6 @@ builtins: (
   {name: "printStackTrace"         ; impl: @mplBuiltinPrintStackTrace         ;}
   {name: "printVariableCount"      ; impl: @mplBuiltinPrintVariableCount      ;}
   {name: "recursive"               ; impl: @mplBuiltinRecursive               ;}
-  #{name: "ref"                    ; impl: @mplBuiltinRef                    ;}
   {name: "rshift"                  ; impl: @mplBuiltinRShift                  ;}
   {name: "same"                    ; impl: @mplBuiltinSame                    ;}
   {name: "schema"                  ; impl: @mplBuiltinSchema                  ;}

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -96,8 +96,8 @@ builtins: (
   {name: "xor"                     ; impl: @mplBuiltinXor                     ;}
 );
 
-builtinFirst: [0 static] func;
-builtinLast: [builtins fieldCount 0 cast 2 /] func;
+builtinFirst: [0 static];
+builtinLast: [builtins fieldCount 0 cast 2 /];
 
 addBuiltin: [
   copy id:;
@@ -117,7 +117,7 @@ addBuiltin: [
 
   bvar: @id VarBuiltin createVariable Virtual makeStaticness;
   nameId bvar NameCaseBuiltin addNameInfo
-] func;
+];
 
 initBuiltins: [
   processor:;
@@ -131,7 +131,7 @@ initBuiltins: [
     p:;
     p.value.name makeStringView p.index addBuiltin
   ] each
-] func;
+];
 
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; index: Int32;} () {convention: cdecl;} [
   processorResult:;

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -1,7 +1,7 @@
 "builtins" module
 
 "control" includeModule
-"builtinImpl" includeModule
+"builtinImpl" useModule
 
 builtins: (
   {name: "!"                       ; impl: @mplBuiltinExclamation             ;}

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -1,97 +1,99 @@
 "builtins" module
-"control" useModule
 
-virtual builtins: (
-  ["!"                       ] [mplBuiltinExclamation             ]
-  ["@"                       ] [mplBuiltinAt                      ]
-  ["+"                       ] [mplBuiltinAdd                     ]
-  ["-"                       ] [mplBuiltinSub                     ]
-  ["*"                       ] [mplBuiltinMul                     ]
-  ["/"                       ] [mplBuiltinDiv                     ]
-  ["&"                       ] [mplBuiltinStrCat                  ]
-  ["="                       ] [mplBuiltinEqual                   ]
-  ["<"                       ] [mplBuiltinLess                    ]
-  [">"                       ] [mplBuiltinGreater                 ]
-  ["^"                       ] [mplBuiltinPow                     ]
-  ["~"                       ] [mplBuiltinNot                     ]
+"control" includeModule
+"builtinImpl" includeModule
 
-  ["addressToReference"      ] [mplBuiltinAddressToReference      ]
-  ["alignment"               ] [mplBuiltinAlignment               ]
-  ["and"                     ] [mplBuiltinAnd                     ]
-  ["array"                   ] [mplBuiltinArray                   ]
-  ["call"                    ] [mplBuiltinCall                    ]
-  ["cast"                    ] [mplBuiltinCast                    ]
-  ["ceil"                    ] [mplBuiltinCeil                    ]
-  ["codeRef"                 ] [mplBuiltinCodeRef                 ]
-  ["cos"                     ] [mplBuiltinCos                     ]
-  #["cref"                    ] [mplBuiltinCref                    ]
-  ["compileOnce"             ] [mplBuiltinCompileOnce             ]
-  ["COMPILER_VERSION"        ] [mplBuiltinCompilerVersion         ]
-  ["const"                   ] [mplBuiltinConst                   ]
-  ["copy"                    ] [mplBuiltinCopy                    ]
-  ["DEBUG"                   ] [mplBuiltinDebug                   ]
-  ["def"                     ] [mplBuiltinDef                     ]
-  ["delete"                  ] [mplBuiltinDelete                  ]
-  #["deref"                   ] [mplBuiltinDeref                   ]
-  #["dirty"                   ] [mplBuiltinDirty                   ]
-  ["dynamic"                 ] [mplBuiltinDirty                   ]
-  ["exportFunction"          ] [mplBuiltinExportFunction          ]
-  ["exportVariable"          ] [mplBuiltinExportVariable          ]
-  ["FALSE"                   ] [mplBuiltinFalse                   ]
-  ["failProc"                ] [mplBuiltinFailProc                ]
-  ["fieldCount"              ] [mplBuiltinFieldCount              ]
-  ["fieldIndex"              ] [mplBuiltinFieldIndex              ]
-  ["fieldName"               ] [mplBuiltinFieldName               ]
-  ["floor"                   ] [mplBuiltinFloor                   ]
-  ["has"                     ] [mplBuiltinHas                     ]
-  ["HAS_LOGS"                ] [mplBuiltinHasLogs                 ]
-  ["if"                      ] [mplBuiltinIf                      ]
-  ["is"                      ] [mplBuiltinIs                      ]
-  ["isMoved"                 ] [mplBuiltinIsMoved                 ]
-  ["importFunction"          ] [mplBuiltinImportFunction          ]
-  ["importVariable"          ] [mplBuiltinImportVariable          ]
-  ["includeModule"           ] [mplBuiltinIncludeModule           ]
-  ["isConst"                 ] [mplBuiltinIsConst                 ]
-  ["isCombined"              ] [mplBuiltinIsCombined              ]
-  ["LF"                      ] [mplBuiltinLF                      ]
-  ["log"                     ] [mplBuiltinLog                     ]
-  ["log10"                   ] [mplBuiltinLog10                   ]
-  ["loop"                    ] [mplBuiltinLoop                    ]
-  ["lshift"                  ] [mplBuiltinLShift                  ]
-  ["manuallyInitVariable"    ] [mplBuiltinManuallyInitVariable    ]
-  ["manuallyDestroyVariable" ] [mplBuiltinManuallyDestroyVariable ]
-  ["mod"                     ] [mplBuiltinMod                     ]
-  ["module"                  ] [mplBuiltinModule                  ]
-  ["move"                    ] [mplBuiltinMove                    ]
-  ["moveIf"                  ] [mplBuiltinMoveIf                  ]
-  ["neg"                     ] [mplBuiltinNeg                     ]
-  ["new"                     ] [mplBuiltinNew                     ]
-  ["newVarOfTheSameType"     ] [mplBuiltinNewVarOfTheSameType     ]
-  ["not"                     ] [mplBuiltinNot                     ]
-  ["or"                      ] [mplBuiltinOr                      ]
-  ["printCompilerMessage"    ] [mplBuiltinPrintCompilerMessage    ]
-  ["printStack"              ] [mplBuiltinPrintStack              ]
-  ["printStackTrace"         ] [mplBuiltinPrintStackTrace         ]
-  ["printVariableCount"      ] [mplBuiltinPrintVariableCount      ]
-  ["recursive"               ] [mplBuiltinRecursive               ]
-  #["ref"                     ] [mplBuiltinRef                     ]
-  ["rshift"                  ] [mplBuiltinRShift                  ]
-  ["same"                    ] [mplBuiltinSame                    ]
-  ["schema"                  ] [mplBuiltinSchema                  ]
-  ["set"                     ] [mplBuiltinSet                     ]
-  ["sin"                     ] [mplBuiltinSin                     ]
-  ["sqrt"                    ] [mplBuiltinSqrt                    ]
-  ["static"                  ] [mplBuiltinStatic                  ]
-  ["storageSize"             ] [mplBuiltinStorageSize             ]
-  ["storageAddress"          ] [mplBuiltinStorageAddress          ]
-  ["textSize"                ] [mplBuiltinTextSize                ]
-  ["textSplit"               ] [mplBuiltinTextSplit               ]
-  ["TRUE"                    ] [mplBuiltinTrue                    ]
-  ["uif"                     ] [mplBuiltinUif                     ]
-  ["ucall"                   ] [mplBuiltinUcall                   ]
-  ["useModule"               ] [mplBuiltinUseModule               ]
-  ["virtual"                 ] [mplBuiltinVirtual                 ]
-  ["xor"                     ] [mplBuiltinXor                     ]
+builtins: (
+  {name: "!"                       ; impl: @mplBuiltinExclamation             ;}
+  {name: "@"                       ; impl: @mplBuiltinAt                      ;}
+  {name: "+"                       ; impl: @mplBuiltinAdd                     ;}
+  {name: "-"                       ; impl: @mplBuiltinSub                     ;}
+  {name: "*"                       ; impl: @mplBuiltinMul                     ;}
+  {name: "/"                       ; impl: @mplBuiltinDiv                     ;}
+  {name: "&"                       ; impl: @mplBuiltinStrCat                  ;}
+  {name: "="                       ; impl: @mplBuiltinEqual                   ;}
+  {name: "<"                       ; impl: @mplBuiltinLess                    ;}
+  {name: ">"                       ; impl: @mplBuiltinGreater                 ;}
+  {name: "^"                       ; impl: @mplBuiltinPow                     ;}
+  {name: "~"                       ; impl: @mplBuiltinNot                     ;}
+
+  {name: "addressToReference"      ; impl: @mplBuiltinAddressToReference      ;}
+  {name: "alignment"               ; impl: @mplBuiltinAlignment               ;}
+  {name: "and"                     ; impl: @mplBuiltinAnd                     ;}
+  {name: "array"                   ; impl: @mplBuiltinArray                   ;}
+  {name: "call"                    ; impl: @mplBuiltinCall                    ;}
+  {name: "cast"                    ; impl: @mplBuiltinCast                    ;}
+  {name: "ceil"                    ; impl: @mplBuiltinCeil                    ;}
+  {name: "codeRef"                 ; impl: @mplBuiltinCodeRef                 ;}
+  {name: "cos"                     ; impl: @mplBuiltinCos                     ;}
+  #{name: "cref"                    ; impl: @mplBuiltinCref                    ;}
+  {name: "compileOnce"             ; impl: @mplBuiltinCompileOnce             ;}
+  {name: "COMPILER_VERSION"        ; impl: @mplBuiltinCompilerVersion         ;}
+  {name: "const"                   ; impl: @mplBuiltinConst                   ;}
+  {name: "copy"                    ; impl: @mplBuiltinCopy                    ;}
+  {name: "DEBUG"                   ; impl: @mplBuiltinDebug                   ;}
+  {name: "def"                     ; impl: @mplBuiltinDef                     ;}
+  {name: "delete"                  ; impl: @mplBuiltinDelete                  ;}
+  #{name: "deref"                   ; impl: @mplBuiltinDeref                   ;}
+  #{name: "dirty"                   ; impl: @mplBuiltinDirty                   ;}
+  {name: "dynamic"                 ; impl: @mplBuiltinDirty                   ;}
+  {name: "exportFunction"          ; impl: @mplBuiltinExportFunction          ;}
+  {name: "exportVariable"          ; impl: @mplBuiltinExportVariable          ;}
+  {name: "FALSE"                   ; impl: @mplBuiltinFalse                   ;}
+  {name: "failProc"                ; impl: @mplBuiltinFailProc                ;}
+  {name: "fieldCount"              ; impl: @mplBuiltinFieldCount              ;}
+  {name: "fieldIndex"              ; impl: @mplBuiltinFieldIndex              ;}
+  {name: "fieldName"               ; impl: @mplBuiltinFieldName               ;}
+  {name: "floor"                   ; impl: @mplBuiltinFloor                   ;}
+  {name: "has"                     ; impl: @mplBuiltinHas                     ;}
+  {name: "HAS_LOGS"                ; impl: @mplBuiltinHasLogs                 ;}
+  {name: "if"                      ; impl: @mplBuiltinIf                      ;}
+  {name: "is"                      ; impl: @mplBuiltinIs                      ;}
+  {name: "isMoved"                 ; impl: @mplBuiltinIsMoved                 ;}
+  {name: "importFunction"          ; impl: @mplBuiltinImportFunction          ;}
+  {name: "importVariable"          ; impl: @mplBuiltinImportVariable          ;}
+  {name: "includeModule"           ; impl: @mplBuiltinIncludeModule           ;}
+  {name: "isConst"                 ; impl: @mplBuiltinIsConst                 ;}
+  {name: "isCombined"              ; impl: @mplBuiltinIsCombined              ;}
+  {name: "LF"                      ; impl: @mplBuiltinLF                      ;}
+  {name: "log"                     ; impl: @mplBuiltinLog                     ;}
+  {name: "log10"                   ; impl: @mplBuiltinLog10                   ;}
+  {name: "loop"                    ; impl: @mplBuiltinLoop                    ;}
+  {name: "lshift"                  ; impl: @mplBuiltinLShift                  ;}
+  {name: "manuallyInitVariable"    ; impl: @mplBuiltinManuallyInitVariable    ;}
+  {name: "manuallyDestroyVariable" ; impl: @mplBuiltinManuallyDestroyVariable ;}
+  {name: "mod"                     ; impl: @mplBuiltinMod                     ;}
+  {name: "module"                  ; impl: @mplBuiltinModule                  ;}
+  {name: "move"                    ; impl: @mplBuiltinMove                    ;}
+  {name: "moveIf"                  ; impl: @mplBuiltinMoveIf                  ;}
+  {name: "neg"                     ; impl: @mplBuiltinNeg                     ;}
+  {name: "new"                     ; impl: @mplBuiltinNew                     ;}
+  {name: "newVarOfTheSameType"     ; impl: @mplBuiltinNewVarOfTheSameType     ;}
+  {name: "not"                     ; impl: @mplBuiltinNot                     ;}
+  {name: "or"                      ; impl: @mplBuiltinOr                      ;}
+  {name: "printCompilerMessage"    ; impl: @mplBuiltinPrintCompilerMessage    ;}
+  {name: "printStack"              ; impl: @mplBuiltinPrintStack              ;}
+  {name: "printStackTrace"         ; impl: @mplBuiltinPrintStackTrace         ;}
+  {name: "printVariableCount"      ; impl: @mplBuiltinPrintVariableCount      ;}
+  {name: "recursive"               ; impl: @mplBuiltinRecursive               ;}
+  #{name: "ref"                    ; impl: @mplBuiltinRef                    ;}
+  {name: "rshift"                  ; impl: @mplBuiltinRShift                  ;}
+  {name: "same"                    ; impl: @mplBuiltinSame                    ;}
+  {name: "schema"                  ; impl: @mplBuiltinSchema                  ;}
+  {name: "set"                     ; impl: @mplBuiltinSet                     ;}
+  {name: "sin"                     ; impl: @mplBuiltinSin                     ;}
+  {name: "sqrt"                    ; impl: @mplBuiltinSqrt                    ;}
+  {name: "static"                  ; impl: @mplBuiltinStatic                  ;}
+  {name: "storageSize"             ; impl: @mplBuiltinStorageSize             ;}
+  {name: "storageAddress"          ; impl: @mplBuiltinStorageAddress          ;}
+  {name: "textSize"                ; impl: @mplBuiltinTextSize                ;}
+  {name: "textSplit"               ; impl: @mplBuiltinTextSplit               ;}
+  {name: "TRUE"                    ; impl: @mplBuiltinTrue                    ;}
+  {name: "uif"                     ; impl: @mplBuiltinUif                     ;}
+  {name: "ucall"                   ; impl: @mplBuiltinUcall                   ;}
+  {name: "useModule"               ; impl: @mplBuiltinUseModule               ;}
+  {name: "virtual"                 ; impl: @mplBuiltinVirtual                 ;}
+  {name: "xor"                     ; impl: @mplBuiltinXor                     ;}
 );
 
 builtinFirst: [0 static] func;
@@ -125,27 +127,21 @@ initBuiltins: [
   currentNode: @codeNode;
   failProc: @failProcForProcessor;
 
-  initBuiltinsInRange: [
-    first:last: copy; copy;
-    i: first copy;
-    [
-      i last < [
-        i 2 * builtins @ call makeStringView i addBuiltin
-        i 1 + @i set
-        TRUE static
-      ] [
-        FALSE static
-      ] if
-    ] loop
-  ] func;
-
-  builtinMiddle: builtinFirst builtinLast + 2 /;
-  builtinFirst builtinMiddle initBuiltinsInRange
-  builtinMiddle builtinLast initBuiltinsInRange
+  builtins makeArrayRange [
+    p:;
+    p.value.name makeStringView p.index addBuiltin
+  ] each
 ] func;
 
-callBuiltin: [
-  builtinFirst builtinLast [
-    2 * 1 + builtins @ call
-  ] staticCall
-] func;
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; index: Int32;} () {convention: cdecl;} [
+  processorResult:;
+  processor:;
+  copy indexOfNode:;
+  currentNode:;
+  multiParserResult:;
+  failProc: @failProcForProcessor;
+  copy index:;
+
+  builtinFunc: index builtins @ .@impl;
+  multiParserResult @currentNode indexOfNode @processor @processorResult @builtinFunc call
+] "callBuiltinImpl" exportFunction

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -33,7 +33,6 @@ builtins: (
   {name: "copy"                    ; impl: @mplBuiltinCopy                    ;}
   {name: "DEBUG"                   ; impl: @mplBuiltinDebug                   ;}
   {name: "def"                     ; impl: @mplBuiltinDef                     ;}
-  {name: "delete"                  ; impl: @mplBuiltinDelete                  ;}
   #{name: "deref"                   ; impl: @mplBuiltinDeref                   ;}
   #{name: "dirty"                   ; impl: @mplBuiltinDirty                   ;}
   {name: "dynamic"                 ; impl: @mplBuiltinDirty                   ;}
@@ -67,7 +66,6 @@ builtins: (
   {name: "move"                    ; impl: @mplBuiltinMove                    ;}
   {name: "moveIf"                  ; impl: @mplBuiltinMoveIf                  ;}
   {name: "neg"                     ; impl: @mplBuiltinNeg                     ;}
-  {name: "new"                     ; impl: @mplBuiltinNew                     ;}
   {name: "newVarOfTheSameType"     ; impl: @mplBuiltinNewVarOfTheSameType     ;}
   {name: "not"                     ; impl: @mplBuiltinNot                     ;}
   {name: "or"                      ; impl: @mplBuiltinOr                      ;}

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1942,6 +1942,7 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
       headVar.capturedTail @endVar.@capturedPrev set # newTail->oldTail
       end                 @headVar.@capturedTail set # head->newTail
       head                 @endVar.@capturedHead set # newTail->head
+      head               @beginVar.@capturedHead set # newTail->head
       end @currentNode.@capturedVars.pushBack       # remember
     ];
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3581,10 +3581,10 @@ makeCompilerPosition: [
         prevNode: fr.value @processor.@nodes.at.get;
         prevNode.state NodeStateCompiled = [
           prevNode.signature currentNode.signature = not [
-            "node was defined with another signature" compilerError
+            ("node " functionName " was defined with another signature") assembleString compilerError
           ] [
             prevNode.mplConvention currentNode.mplConvention = not [
-              "node was defined with another convention" compilerError
+              ("node " functionName " was defined with another convention") assembleString compilerError
             ] [
               currentNode.nodeCase NodeCaseDllDeclaration = [
                 prevNode.nodeCase NodeCaseDllDeclaration = not [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3152,16 +3152,19 @@ makeCompilerPosition: [
   String @currentNode.@header set
   String @currentNode.@signature set
 
+  inputCountMismatch: [
+    ("In signature there are " forcedSignature.inputs.getSize " inputs, but really here " currentNode.buildingMatchingInfo.inputs.getSize " inputs") assembleString compilerError
+  ];
+
   hasForcedSignature [
     currentNode.buildingMatchingInfo.inputs.getSize forcedSignature.inputs.getSize = not [
-      currentNode.buildingMatchingInfo.inputs.getSize 0 =
-      [forcedSignature.inputs.getSize 1 =] &&
-      [forcedSignature.outputs.getSize 1 =] &&
-      [0 forcedSignature.outputs.at 0 forcedSignature.inputs.at variablesAreSame] && [
+      currentNode.buildingMatchingInfo.inputs.getSize 1 + forcedSignature.inputs.getSize =
+      [forcedSignature.outputs.getSize 0 >] &&
+      [0 forcedSignature.outputs.at forcedSignature.inputs.last variablesAreSame] && [
         #todo for MPL signature check each
         pop push
       ] [
-        ("In signature there are " forcedSignature.inputs.getSize " inputs, but really here " currentNode.buildingMatchingInfo.inputs.getSize " inputs") assembleString compilerError
+        inputCountMismatch
       ] if
     ] when
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1607,7 +1607,7 @@ tryImplicitLambdaCast: [
   };
 
   varSrc: refToSrc getVar;
-  varSrc.data.getTag VarCode = [
+  varSrc.data.getTag VarCode = [refToDst isVirtual not] && [
     dstPointee: refToDst getPossiblePointee;
     dstPointeeVar: dstPointee getVar;
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -548,8 +548,9 @@ setVar: [
   ] loop
 ];
 
-createRef: [
-  mutable:;
+createRefWith: [
+  copy createOperation:;
+  copy mutable:;
   refToVar:;
 
   refToVar isVirtual [
@@ -565,11 +566,14 @@ createRef: [
 
     newRefToVar: refToVar VarRef createVariable;
     mutable refToVar.mutable and @newRefToVar.@mutable set
-    refToVar newRefToVar createRefOperation
+    createOperation [refToVar newRefToVar createRefOperation] when
     newRefToVar
     #] if
   ] if
 ];
+
+createRef: [TRUE dynamic createRefWith];
+createRefNoOp: [FALSE dynamic createRefWith];
 
 createCheckedStaticGEP: [
   refToStruct:;
@@ -938,7 +942,7 @@ createNamedVariable: [
       ] [
         #"do you mean or or copy?" compilerError
         TRUE @var.@capturedAsMutable set #we need ref
-        refToVar TRUE createRef @newRefToVar set
+        refToVar TRUE currentNode.nextLabelIsSchema not createRefWith @newRefToVar set
         newRefToVar isGlobalLabel [newRefToVar makeVarTreeDirty] when
       ] if
     ] if

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -914,7 +914,12 @@ createNamedVariable: [
       ] when
     ] when
 
-    var.temporary [currentNode.nextLabelIsVirtual not] && [refToVar isGlobal] && [
+    isGlobalLabel: [
+      refToVar:;
+      currentNode.nextLabelIsVirtual not [refToVar isVirtual not] && [refToVar isGlobal] &&
+    ];
+
+    var.temporary [refToVar isGlobalLabel] &&  [
       refToVar makeVarTreeDirty
       Dirty @staticness set
     ] when
@@ -930,6 +935,7 @@ createNamedVariable: [
         #"do you mean or or copy?" compilerError
         TRUE @var.@capturedAsMutable set #we need ref
         refToVar TRUE createRef @newRefToVar set
+        newRefToVar isGlobalLabel [newRefToVar makeVarTreeDirty] when
       ] if
     ] if
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -685,7 +685,11 @@ makeVirtualVarReal: [
                 ] [
                   lastSrc isPlain [
                     lastSrc lastDst createStoreConstant
-                  ] when
+                  ] [
+                    varSrc.data.getTag VarString = [
+                      lastDst createStringIRNoAlloc drop
+                    ] when
+                  ] if
                 ] if
               ] when
             ] if

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -753,6 +753,11 @@ makeVarVirtual: [
   ] when
 ];
 
+makeVarRealCaptured: [
+  refToVar:;
+  TRUE refToVar getVar.@capturedAsRealValue set
+];
+
 makeVarTreeDirty: [
   refToVar:;
   unfinishedVars: RefToVar Array;
@@ -804,6 +809,7 @@ makePointeeDirtyIfRef: [
   var: refToVar getVar;
   var.data.getTag VarRef = [var.staticness Static =] && [
     pointee: refToVar getPointeeWhileDynamize;
+    pointee makeVarRealCaptured
     pointee.mutable [pointee makeVarTreeDirty] when
   ] when
 ];

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -905,7 +905,7 @@ createNamedVariable: [
 
     currentNode.nextLabelIsVirtual [
       refToVar isVirtual not [
-        staticness Dynamic > not ["value for virtual label must me static" makeStringView compilerError] when
+        staticness Dynamic > not ["value for virtual label must be static" makeStringView compilerError] when
         staticness Weak    =     [Static @var.@staticness set] when
       ] when
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2956,7 +2956,7 @@ finalizeCodeNode: [
     forcedSignature.convention @currentNode.@mplConvention set
   ] [
     String @currentNode.@convention set
-    "-" toString @currentNode.@mplConvention set
+    "" toString @currentNode.@mplConvention set
   ] if
 
   (retType "(" signature ")") assembleString @currentNode.@signature set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3528,14 +3528,17 @@ astNodeToCodeNodeImpl: [
     processor.depthOfRecursion @processor.@maxDepthOfRecursion set
   ] when
 
-  processor.depthOfRecursion 255 > [
-    "max depth of recursion (256) exceeded" makeStringView compilerError
-    TRUE dynamic @processor.@maxDepthExceeded set
+  maxDepthOfRecursion: 256;
+  maxDepthOfPre:       64;
+
+  processor.depthOfRecursion maxDepthOfRecursion > [
+    ("max depth of recursion (" maxDepthOfRecursion ") exceeded") assembleString compilerError
+    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
 
-  processor.depthOfPre 64 > [
-    "max depth of PRE recursion (64) exceeded" makeStringView compilerError
-    TRUE dynamic @processor.@maxDepthExceeded set
+  processor.depthOfPre maxDepthOfPre > [
+    ("max depth of PRE recursion (" maxDepthOfPre ") exceeded") assembleString compilerError
+    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
 
   addr: indexArray storageAddress;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1360,17 +1360,14 @@ captureName: [
   result
 ] func;
 
-isBuiltinOrImport: [
-  var: getVar;
-  var.data.getTag VarBuiltin =
-  [var.data.getTag VarImport =] ||
-] func;
 
 isCallable: [
   refToVar:;
-  refToVar isBuiltinOrImport
-  [
-    refToVar getVar.data.getTag VarStruct = [
+  var: refToVar getVar;
+  var.data.getTag VarBuiltin =
+  [var.data.getTag VarCode =] ||
+  [var.data.getTag VarImport =] || [
+    var.data.getTag VarStruct = [
       processor.callNameInfo refToVar findField.success copy
     ] &&
   ] ||
@@ -1567,14 +1564,20 @@ callCallable: [
   var.data.getTag VarBuiltin = [
     VarBuiltin var.data.get callBuiltin
   ] [
-    var.data.getTag VarImport = [
-      #VarImport var.data.get processor.nodes.at.get callImport
-      refToVar processFuncPtr
+    var.data.getTag VarCode = [
+      object regNamesSelf
+      VarCode var.data.get @name processCall
+      object unregNamesSelf
     ] [
-      var.data.getTag VarStruct = [
-        @predicate call
+      var.data.getTag VarImport = [
+        #VarImport var.data.get processor.nodes.at.get callImport
+        refToVar processFuncPtr
       ] [
-        [FALSE] "Wrong type to call!" assert
+        var.data.getTag VarStruct = [
+          @predicate call
+        ] [
+          [FALSE] "Wrong type to call!" assert
+        ] if
       ] if
     ] if
   ] if

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1874,6 +1874,9 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
       beginVar: begin getVar;
       endVar: end getVar;
       global: refToVar isGlobal;
+      
+      var.storageStaticness @beginVar.@storageStaticness set
+      var.storageStaticness   @endVar.@storageStaticness set
 
       global [
         reason ShadowReasonField = not [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -431,6 +431,10 @@ getField: [
         psBegin @fieldShadow set
         psEnd @fieldRefToVar set
       ] if
+
+      var.staticness fieldRefToVar getVar.staticness < [
+        var.staticness fieldRefToVar getVar.@staticness set
+      ] when
     ] when
 
     refToVar.mutable @fieldRefToVar.@mutable set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2692,7 +2692,6 @@ unregCodeNodeNames: [
   @currentNode.@usedModulesTable.release
   @currentNode.@includedModulesTable.release
   @currentNode.@directlyIncludedModulesTable.release
-  @currentNode.@usedOrIncludedModulesTable.release
   @currentNode.@captureTable.release
   @currentNode.@fieldCaptureTable.release
   #] when

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -33,7 +33,7 @@ compilable: [processorResult.success copy] func;
   processor: Processor Ref;
   indexOfNode: Int32;
   currentNode: CodeNode Ref;
-  multiParserResult: MultiParserResult Cref; 
+  multiParserResult: MultiParserResult Cref;
   positionInfo: CompilerPositionInfo Cref;
   name: StringView Cref;
   nodeCase: NodeCaseCode;
@@ -54,7 +54,7 @@ compilable: [processorResult.success copy] func;
   processor: Processor Ref;
   indexOfNode: Int32;
   currentNode: CodeNode Ref;
-  multiParserResult: MultiParserResult Cref; 
+  multiParserResult: MultiParserResult Cref;
   refToVar: RefToVar Cref;
 } () {convention: cdecl;} "processFuncPtrImpl" importFunction
 
@@ -3097,7 +3097,7 @@ finalizeCodeNode: [
   ] func;
 
   noname: hasForcedSignature not;
-    #[currentNode.nodeCase NodeCaseLambda =] ||;
+  #[currentNode.nodeCase NodeCaseLambda =] ||;
 
   currentNode.nodeCase NodeCaseEmpty = [
     noname

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3624,6 +3624,8 @@ makeCompilerPosition: [
   ] when
 
   checkRecursionOfCodeNode
+
+  compilable not [TRUE @currentNode.@empty set] when
 ] "finalizeCodeNodeImpl" exportFunction
 
 finalizeCodeNode: [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2663,8 +2663,6 @@ deleteNode: [
   node: nodeIndex @processor.@nodes.at.get;
   TRUE dynamic @node.@empty   set
   TRUE dynamic @node.@deleted set
-  MatchingInfo @node.@buildingMatchingInfo set
-  MatchingInfo @node.@matchingInfo set
   @node.@program.release
 
   #@node.@variables [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2510,7 +2510,7 @@ processNode: [
 addNamesFromModule: [
   copy moduleId:;
 
-  fru: current currentNode.usedOrIncludedModulesTable.find;
+  fru: moduleId currentNode.usedOrIncludedModulesTable.find;
   fru.success not [
     moduleId TRUE @currentNode.@usedOrIncludedModulesTable.insert
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -5,14 +5,6 @@
 "variable" includeModule
 "processor" includeModule
 
-callBuiltin:           [multiParserResult @currentNode indexOfNode @processor @processorResult callBuiltinImpl];
-processFuncPtr:        [multiParserResult @currentNode indexOfNode @processor @processorResult processFuncPtrImpl];
-processPre:            [multiParserResult @currentNode indexOfNode @processor @processorResult processPreImpl];
-processCall:           [multiParserResult @currentNode indexOfNode @processor @processorResult processCallImpl];
-processExportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processExportFunctionImpl];
-processImportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processImportFunctionImpl];
-compareEntriesRec:     [currentMatchingNodeIndex @nestedToCur @curToNested @comparingMessage multiParserResult @currentNode indexOfNode @processor @processorResult compareEntriesRecImpl];
-
 addOverload: [
   copy nameId:;
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -762,30 +762,32 @@ makeVarTreeDirty: [
       var: lastRefToVar getVar;
       lastRefToVar staticnessOfVar Virtual = ["can't dynamize virtual value" makeStringView compilerError] when
 
-      var.data.getTag VarStruct = [
-        struct: VarStruct var.data.get.get;
-        j: 0 dynamic;
-        [
-          j struct.fields.dataSize < [
-            j struct.fields.at.refToVar isVirtualField not [
-              j lastRefToVar getField @unfinishedVars.pushBack
-            ] when
-            j 1 + @j set TRUE
-          ] &&
-        ] loop
-      ] [
-        var.data.getTag VarRef = [
-          lastRefToVar staticnessOfVar Static = [
-            pointee: lastRefToVar getPointeeWhileDynamize;
-            pointee.mutable [pointee @unfinishedVars.pushBack] when
-          ] [
-            [lastRefToVar staticnessOfVar Dynamic > not] "Ref must be only Static or Dynamic!" assert
-          ] if
-        ] when
-      ] if
+      compilable [
+        var.data.getTag VarStruct = [
+          struct: VarStruct var.data.get.get;
+          j: 0 dynamic;
+          [
+            j struct.fields.dataSize < [
+              j struct.fields.at.refToVar isVirtualField not [
+                j lastRefToVar getField @unfinishedVars.pushBack
+              ] when
+              j 1 + @j set TRUE
+            ] &&
+          ] loop
+        ] [
+          var.data.getTag VarRef = [
+            lastRefToVar staticnessOfVar Static = [
+              pointee: lastRefToVar getPointeeWhileDynamize;
+              pointee.mutable [pointee @unfinishedVars.pushBack] when
+            ] [
+              [lastRefToVar staticnessOfVar Dynamic > not] "Ref must be only Static or Dynamic!" assert
+            ] if
+          ] when
+        ] if
 
-      var.data.getTag VarImport = not [
-        lastRefToVar Dirty makeStaticness @lastRefToVar set
+        var.data.getTag VarImport = not [
+          lastRefToVar Dirty makeStaticness @lastRefToVar set
+        ] when
       ] when
 
       compilable

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -5,13 +5,13 @@
 "variable" includeModule
 "processor" includeModule
 
-callBuiltin:           [multiParserResult @currentNode indexOfNode @processor @processorResult callBuiltinImpl] func;
-processFuncPtr:        [multiParserResult @currentNode indexOfNode @processor @processorResult processFuncPtrImpl] func;
-processPre:            [multiParserResult @currentNode indexOfNode @processor @processorResult processPreImpl] func;
-processCall:           [multiParserResult @currentNode indexOfNode @processor @processorResult processCallImpl] func;
-processExportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processExportFunctionImpl] func;
-processImportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processImportFunctionImpl] func;
-compareEntriesRec:     [currentMatchingNodeIndex @nestedToCur @curToNested @comparingMessage multiParserResult @currentNode indexOfNode @processor @processorResult compareEntriesRecImpl] func;
+callBuiltin:           [multiParserResult @currentNode indexOfNode @processor @processorResult callBuiltinImpl];
+processFuncPtr:        [multiParserResult @currentNode indexOfNode @processor @processorResult processFuncPtrImpl];
+processPre:            [multiParserResult @currentNode indexOfNode @processor @processorResult processPreImpl];
+processCall:           [multiParserResult @currentNode indexOfNode @processor @processorResult processCallImpl];
+processExportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processExportFunctionImpl];
+processImportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processImportFunctionImpl];
+compareEntriesRec:     [currentMatchingNodeIndex @nestedToCur @curToNested @comparingMessage multiParserResult @currentNode indexOfNode @processor @processorResult compareEntriesRecImpl];
 
 addOverload: [
   copy nameId:;
@@ -24,13 +24,13 @@ addOverload: [
     "bad overload index" makeStringView compilerError
     -1
   ] if
-] func;
+];
 
 getOverloadCount: [
   copy nameId:;
   overloads: nameId processor.nameInfos.at.stack;
   overloads.getSize
-] func;
+];
 
 addNameInfoWith: [
   copy reg:;
@@ -105,11 +105,11 @@ addNameInfoWith: [
   ] [
     #we add "self" or "closure" but dont use them in program
   ] if
-] func;
+];
 
-addNameInfo: [indexOfNode copy -1 dynamic TRUE addNameInfoWith] func;
-addNameInfoOverloaded: [TRUE addNameInfoWith] func;
-addNameInfoNoReg: [indexOfNode copy -1 dynamic FALSE addNameInfoWith] func;
+addNameInfo: [indexOfNode copy -1 dynamic TRUE addNameInfoWith];
+addNameInfoOverloaded: [TRUE addNameInfoWith];
+addNameInfoNoReg: [indexOfNode copy -1 dynamic FALSE addNameInfoWith];
 
 getNameLastIndexInfo: [
   nameId:;
@@ -119,7 +119,7 @@ getNameLastIndexInfo: [
   currentNameInfo.stack.dataSize 1 - @result.@overload set
   currentNameInfo.stack.last.dataSize 1 - @result.@index set
   result
-] func;
+];
 
 deleteNameInfoWithOverload: [
   copy nameId:;
@@ -136,14 +136,14 @@ deleteNameInfoWithOverload: [
       TRUE
     ] &&
   ] loop
-] func;
+];
 
 deleteNameInfo: [
   copy nameId:;
 
   currentNameInfo: nameId @processor.@nameInfos.at;
   currentNameInfo.stack.dataSize 1 - nameId deleteNameInfoWithOverload
-] func;
+];
 
 makeStaticness: [
   copy staticness:;
@@ -159,7 +159,7 @@ makeStaticness: [
   ] when
 
   refToVar copy
-] func;
+];
 
 makeStorageStaticness: [
   copy staticness:;
@@ -170,11 +170,11 @@ makeStorageStaticness: [
   ] when
 
   refToVar
-] func;
+];
 
 createVariable: [
   FALSE dynamic TRUE dynamic createVariableWithVirtual
-] func;
+];
 
 createVariableWithVirtual: [
   copy makeType:;
@@ -228,12 +228,12 @@ createVariableWithVirtual: [
   ] when
 
   result
-] func;
+];
 
 push: [
   entry:;
   entry @currentNode.@stack.pushBack
-] func;
+];
 
 getStackEntryForPreInput: [
   copy depth:;
@@ -243,28 +243,28 @@ getStackEntryForPreInput: [
   shadowEnd: RefToVar;
   entry @shadowBegin @shadowEnd ShadowReasonInput makeShadows
   shadowEnd
-] func;
+];
 
-makeVarCode:   [VarCode   createVariable] func;
-makeVarString: [VarString createVariable createStringIR] func;
+makeVarCode:   [VarCode   createVariable];
+makeVarString: [VarString createVariable createStringIR];
 
-makeVarInt8:   [VarInt8   checkValue VarInt8   createVariable createPlainIR] func;
-makeVarInt16:  [VarInt16  checkValue VarInt16  createVariable createPlainIR] func;
-makeVarInt32:  [VarInt32  checkValue VarInt32  createVariable createPlainIR] func;
-makeVarInt64:  [VarInt64  checkValue VarInt64  createVariable createPlainIR] func;
-makeVarIntX:   [VarIntX   checkValue VarIntX   createVariable createPlainIR] func;
-makeVarNat8:   [VarNat8   checkValue VarNat8   createVariable createPlainIR] func;
-makeVarNat16:  [VarNat16  checkValue VarNat16  createVariable createPlainIR] func;
-makeVarNat32:  [VarNat32  checkValue VarNat32  createVariable createPlainIR] func;
-makeVarNat64:  [VarNat64  checkValue VarNat64  createVariable createPlainIR] func;
-makeVarNatX:   [VarNatX   checkValue VarNatX   createVariable createPlainIR] func;
-makeVarReal32: [VarReal32 checkValue VarReal32 createVariable createPlainIR] func;
-makeVarReal64: [VarReal64 checkValue VarReal64 createVariable createPlainIR] func;
+makeVarInt8:   [VarInt8   checkValue VarInt8   createVariable createPlainIR];
+makeVarInt16:  [VarInt16  checkValue VarInt16  createVariable createPlainIR];
+makeVarInt32:  [VarInt32  checkValue VarInt32  createVariable createPlainIR];
+makeVarInt64:  [VarInt64  checkValue VarInt64  createVariable createPlainIR];
+makeVarIntX:   [VarIntX   checkValue VarIntX   createVariable createPlainIR];
+makeVarNat8:   [VarNat8   checkValue VarNat8   createVariable createPlainIR];
+makeVarNat16:  [VarNat16  checkValue VarNat16  createVariable createPlainIR];
+makeVarNat32:  [VarNat32  checkValue VarNat32  createVariable createPlainIR];
+makeVarNat64:  [VarNat64  checkValue VarNat64  createVariable createPlainIR];
+makeVarNatX:   [VarNatX   checkValue VarNatX   createVariable createPlainIR];
+makeVarReal32: [VarReal32 checkValue VarReal32 createVariable createPlainIR];
+makeVarReal64: [VarReal64 checkValue VarReal64 createVariable createPlainIR];
 
 makeConst: [
   var:;
   FALSE dynamic @var.@mutable set
-] func;
+];
 
 getPointeeForMatching: [
   refToVar:;
@@ -274,7 +274,7 @@ getPointeeForMatching: [
   result: pointee copy;
   refToVar.mutable pointee.mutable and @result.@mutable set # to deref is
   result
-] func;
+];
 
 getPointeeWith: [
   copy dynamize:;
@@ -370,11 +370,11 @@ getPointeeWith: [
     refToVar.mutable pointee.mutable and @result.@mutable set # to deref is
     result
   ] if
-] func;
+];
 
-getPointee:              [TRUE  FALSE getPointeeWith] func;
-getPointeeNoDerefIR:     [FALSE FALSE getPointeeWith] func;
-getPointeeWhileDynamize: [FALSE TRUE  getPointeeWith] func;
+getPointee:              [TRUE  FALSE getPointeeWith];
+getPointeeNoDerefIR:     [FALSE FALSE getPointeeWith];
+getPointeeWhileDynamize: [FALSE TRUE  getPointeeWith];
 
 getFieldForMatching: [
   refToVar:;
@@ -402,7 +402,7 @@ getFieldForMatching: [
     "index is out of bounds" makeStringView compilerError
     RefToVar
   ] if
-] func;
+];
 
 getField: [
   refToVar:;
@@ -449,7 +449,7 @@ getField: [
     failResult: RefToVar Ref;
     @failResult
   ] if
-] func;
+];
 
 captureEntireStruct: [
   refToVar:;
@@ -476,7 +476,7 @@ captureEntireStruct: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 setOneVar: [
   copy first:;
@@ -509,7 +509,7 @@ setOneVar: [
       refSrc staticness makeStaticness drop:;
     ] when
   ] if
-] func;
+];
 
 setVar: [
   copy refDst:;
@@ -550,7 +550,7 @@ setVar: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 createRef: [
   mutable:;
@@ -573,7 +573,7 @@ createRef: [
     newRefToVar
     #] if
   ] if
-] func;
+];
 
 createCheckedStaticGEP: [
   refToStruct:;
@@ -587,7 +587,7 @@ createCheckedStaticGEP: [
     fieldRef index refToStruct createStaticGEP
     currentNode.program.dataSize 1 - @fieldVar.@getInstructionIndex set
   ] when
-] func;
+];
 
 makeVirtualVarReal: [
   refToVar:;
@@ -709,7 +709,7 @@ makeVirtualVarReal: [
 
     realValue copy
   ] if
-] func;
+];
 
 makeVarVirtual: [
   refToVar:;
@@ -751,7 +751,7 @@ makeVarVirtual: [
   compilable [
     msr: refToVar Virtual makeStaticness;
   ] when
-] func;
+];
 
 makeVarTreeDirty: [
   refToVar:;
@@ -795,7 +795,7 @@ makeVarTreeDirty: [
       compilable
     ] &&
   ] loop
-] func;
+];
 
 makePointeeDirtyIfRef: [
   refToVar:;
@@ -804,7 +804,7 @@ makePointeeDirtyIfRef: [
     pointee: refToVar getPointeeWhileDynamize;
     pointee.mutable [pointee makeVarTreeDirty] when
   ] when
-] func;
+];
 
 makeVarDynamicOrDirty: [
   newStaticness:;
@@ -813,10 +813,10 @@ makeVarDynamicOrDirty: [
 
   refToVar makePointeeDirtyIfRef
   msr: refToVar newStaticness makeStaticness;
-] func;
+];
 
-makeVarDynamic: [Dynamic makeVarDynamicOrDirty] func;
-makeVarDirty:   [Dirty   makeVarDynamicOrDirty] func;
+makeVarDynamic: [Dynamic makeVarDynamicOrDirty];
+makeVarDirty:   [Dirty   makeVarDynamicOrDirty];
 
 makeVarTreeDynamicWith: [
   copy dynamicStoraged:;
@@ -865,10 +865,10 @@ makeVarTreeDynamicWith: [
       compilable
     ] &&
   ] loop
-] func;
+];
 
-makeVarTreeDynamic:         [FALSE dynamic makeVarTreeDynamicWith] func;
-makeVarTreeDynamicStoraged: [TRUE  dynamic makeVarTreeDynamicWith] func;
+makeVarTreeDynamic:         [FALSE dynamic makeVarTreeDynamicWith];
+makeVarTreeDynamicStoraged: [TRUE  dynamic makeVarTreeDynamicWith];
 
 addOverloadForPre: [
   refToVar:;
@@ -883,7 +883,7 @@ addOverloadForPre: [
       overload @struct.@structName.@nameOverload set
     ] when
   ] when
-] func;
+];
 
 createNamedVariable: [
   refToVar:;
@@ -956,34 +956,34 @@ createNamedVariable: [
       newField @currentNode.@struct.@fields.pushBack
     ] when
   ] when
-] func;
+];
 
 processLabelNode: [
   .nameInfo pop createNamedVariable
-] func;
+];
 
 processCodeNode: [
   data:;
   indexOfAstNode makeVarCode push
-] func;
+];
 
 processCallByIndexArray: [
   multiParserResult @currentNode indexOfNode @processor @processorResult processCallByIndexArrayImpl
-] func;
+];
 
 processObjectNode: [
   data:;
   position: currentNode.position copy;
   name: "objectInitializer" makeStringView;
   data NodeCaseObject dynamic name position processCallByIndexArray
-] func;
+];
 
 processListNode: [
   data:;
   position: currentNode.position copy;
   name: "listInitializer" makeStringView;
   data NodeCaseList dynamic name position processCallByIndexArray
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -1047,7 +1047,7 @@ findLocalObject: [
     ] &&
   ] loop
   refToVar
-] func;
+];
 
 findNameStackObject: [
   copy nameCase:;
@@ -1069,7 +1069,7 @@ findNameStackObject: [
   ] loop
 
   result
-] func;
+];
 
 getNameAs: [
   copy overload:;
@@ -1083,7 +1083,7 @@ getNameAs: [
     ] [
       ("unknown name:" name) assembleString compilerError
     ] if
-  ] func;
+  ];
 
   result: {
     refToVar: RefToVar;
@@ -1150,7 +1150,7 @@ getNameAs: [
           ] [
             refToVar copy
           ] if
-        ] func;
+        ];
 
         result.refToVar moveToTail @result.@refToVar set
         result.object moveToTail @result.@object set
@@ -1164,20 +1164,20 @@ getNameAs: [
     unknownName
   ] if
   result
-] func;
+];
 
-getName: [Capture FALSE dynamic -1 dynamic getNameAs] func;
-getNameForMatching: [TRUE dynamic -1 dynamic getNameAs] func;
+getName: [Capture FALSE dynamic -1 dynamic getNameAs];
+getNameForMatching: [TRUE dynamic -1 dynamic getNameAs];
 
 getNameWithOverload: [
   copy overload:;
   Capture FALSE dynamic overload getNameAs
-] func;
+];
 
 getNameForMatchingWithOverload: [
   copy overload:;
   TRUE dynamic overload getNameAs
-] func;
+];
 
 captureName: [
   getNameResult:;
@@ -1296,7 +1296,7 @@ captureName: [
       ] if
 
       result
-    ] func;
+    ];
 
     # now we must capture and create GEP instruction
     getNameResult.mplFieldIndex 0 < not [
@@ -1358,7 +1358,7 @@ captureName: [
   ] if
 
   result
-] func;
+];
 
 
 isCallable: [
@@ -1371,7 +1371,7 @@ isCallable: [
       processor.callNameInfo refToVar findField.success copy
     ] &&
   ] ||
-] func;
+];
 
 addFieldsNameInfos: [
   copy addNameCase:;
@@ -1390,7 +1390,7 @@ addFieldsNameInfos: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 deleteFieldsNameInfos: [
   refToVar:;
@@ -1407,7 +1407,7 @@ deleteFieldsNameInfos: [
       currentField.nameInfo deleteNameInfo # name info pointing to the struct, not to a field!
     ] &&
   ] loop
-] func;
+];
 
 regNamesClosure: [
   object:;
@@ -1417,7 +1417,7 @@ regNamesClosure: [
     processor.closureNameInfo object NameCaseClosureObject addNameInfoNoReg
     object NameCaseClosureMember addFieldsNameInfos
   ] when
-] func;
+];
 
 regNamesSelf: [
   object:;
@@ -1427,7 +1427,7 @@ regNamesSelf: [
     processor.selfNameInfo object NameCaseSelfObject addNameInfoNoReg
     object NameCaseSelfMember addFieldsNameInfos
   ] when
-] func;
+];
 
 unregNamesClosure: [
   object:;
@@ -1435,7 +1435,7 @@ unregNamesClosure: [
     object deleteFieldsNameInfos
     processor.closureNameInfo deleteNameInfo
   ] when
-] func;
+];
 
 unregNamesSelf: [
   object:;
@@ -1443,7 +1443,7 @@ unregNamesSelf: [
     object deleteFieldsNameInfos
     processor.selfNameInfo deleteNameInfo
   ] when
-] func;
+];
 
 callCallableStruct: [
   name:;
@@ -1469,7 +1469,7 @@ callCallableStruct: [
   ] [
     "CALL field is not a code" compilerError
   ] if
-] func;
+];
 
 callCallableField: [
   name:;
@@ -1483,7 +1483,7 @@ callCallableField: [
   object regNamesClosure
   code @name processCall
   object unregNamesClosure
-] func;
+];
 
 callCallableStructWithPre: [
   name:;
@@ -1552,7 +1552,7 @@ callCallableStructWithPre: [
 
     nextIteration [compilable] &&
   ] loop
-] func;
+];
 
 callCallable: [
   predicate:;
@@ -1581,7 +1581,7 @@ callCallable: [
       ] if
     ] if
   ] if
-] func;
+];
 
 getPossiblePointee: [
   refToVar:;
@@ -1591,11 +1591,11 @@ getPossiblePointee: [
     refToVar copy
   ] if
 
-] func;
+];
 
 derefAndPush: [
   getPossiblePointee push
-] func;
+];
 
 tryImplicitLambdaCast: [
   refToDst:;
@@ -1655,7 +1655,7 @@ tryImplicitLambdaCast: [
   ] when
 
   result
-] func;
+];
 
 setRef: [
   compileOnce
@@ -1699,7 +1699,7 @@ setRef: [
       ] if
     ] when
   ] if
-] func;
+];
 
 copyOneVarWith: [
   copy toNew:;
@@ -1711,7 +1711,7 @@ copyOneVarWith: [
 
   checkedStaticnessOfVar: [
     toNew [staticnessOfVar Dynamic maxStaticness] [staticnessOfVar] if
-  ] func;
+  ];
 
   srcVar.data.getTag VarStruct = [
     srcStruct: VarStruct srcVar.data.get.get;
@@ -1749,7 +1749,7 @@ copyOneVarWith: [
   srcVar.dbgTypeId @dstVar.@dbgTypeId set
 
   dst
-] func;
+];
 
 copyVarImpl: [
   copy toNew:;
@@ -1803,13 +1803,13 @@ copyVarImpl: [
     ] loop
     result
   ] if
-] func;
+];
 
-copyOneVar: [FALSE dynamic copyOneVarWith] func;
+copyOneVar: [FALSE dynamic copyOneVarWith];
 
-copyVar:          [FALSE FALSE dynamic copyVarImpl] func; #fromchild is static arg
-copyVarFromChild: [TRUE  FALSE dynamic copyVarImpl] func;
-copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl] func;
+copyVar:          [FALSE FALSE dynamic copyVarImpl]; #fromchild is static arg
+copyVarFromChild: [TRUE  FALSE dynamic copyVarImpl];
+copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
 
 {
   dynamicStoraged: Cond;
@@ -1895,7 +1895,7 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl] func;
       end                 @headVar.@capturedTail set # head->newTail
       head                 @endVar.@capturedHead set # newTail->head
       end @currentNode.@capturedVars.pushBack       # remember
-    ] func;
+    ];
 
     dynamicStoraged [
       reallyCreateShadows
@@ -1926,12 +1926,12 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl] func;
 makeShadows:        [
   multiParserResult @currentNode indexOfNode @processor @processorResult
   FALSE makeShadowsImpl
-] func;
+];
 
 makeShadowsDynamic: [
   multiParserResult @currentNode indexOfNode @processor @processorResult
   TRUE  makeShadowsImpl
-] func;
+];
 
 {
   forMatching: Cond;
@@ -2013,13 +2013,13 @@ pop:            [
   result: RefToVar;
   @result multiParserResult @currentNode indexOfNode @processor @processorResult FALSE popImpl
   result
-] func;
+];
 
 popForMatching: [
   result: RefToVar;
   @result multiParserResult @currentNode indexOfNode @processor @processorResult TRUE popImpl
   result
-] func;
+];
 
 pushName: [
   copy nameInfo:;
@@ -2045,7 +2045,7 @@ pushName: [
       ] if
     ] if
   ] if
-] func;
+];
 
 processNameNode: [
   data:;
@@ -2056,7 +2056,7 @@ processNameNode: [
   compilable [
     cnr.object refToVar 0 data.nameInfo pushName
   ] when
-] func;
+];
 
 processNameReadNode: [
   data:;
@@ -2076,7 +2076,7 @@ processNameReadNode: [
       ] if
     ] if
   ] when
-] func;
+];
 
 processNameWriteNode: [
   data:;
@@ -2085,7 +2085,7 @@ processNameWriteNode: [
   refToVar: cnr.refToVar;
 
   compilable [refToVar setRef] when
-] func;
+];
 
 processStaticAt: [
   refToStruct:;
@@ -2108,7 +2108,7 @@ processStaticAt: [
   ] [
     RefToVar
   ] if
-] func;
+];
 
 processMember: [
   copy read:;
@@ -2120,7 +2120,7 @@ processMember: [
 
     fieldError: [
       (refToStruct getMplType " has no field " data.name) assembleString compilerError
-    ] func;
+    ];
 
     refToStruct getVar.data.getTag VarRef = [
       refToStruct isVirtualRef [
@@ -2163,25 +2163,25 @@ processMember: [
       ] if
     ] when
   ] when
-] func;
+];
 
-processNameMemberNode: [pop 0 dynamic processMember] func;
-processNameReadMemberNode: [pop 1 dynamic processMember] func;
-processNameWriteMemberNode: [pop -1 dynamic processMember] func;
+processNameMemberNode: [pop 0 dynamic processMember];
+processNameReadMemberNode: [pop 1 dynamic processMember];
+processNameWriteMemberNode: [pop -1 dynamic processMember];
 
-processStringNode: [makeVarString push] func;
-processInt8Node:   [makeVarInt8   push] func;
-processInt16Node:  [makeVarInt16  push] func;
-processInt32Node:  [makeVarInt32  push] func;
-processInt64Node:  [makeVarInt64  push] func;
-processIntXNode:   [makeVarIntX   push] func;
-processNat8Node:   [makeVarNat8   push] func;
-processNat16Node:  [makeVarNat16  push] func;
-processNat32Node:  [makeVarNat32  push] func;
-processNat64Node:  [makeVarNat64  push] func;
-processNatXNode:   [makeVarNatX   push] func;
-processReal32Node: [makeVarReal32 push] func;
-processReal64Node: [makeVarReal64 push] func;
+processStringNode: [makeVarString push];
+processInt8Node:   [makeVarInt8   push];
+processInt16Node:  [makeVarInt16  push];
+processInt32Node:  [makeVarInt32  push];
+processInt64Node:  [makeVarInt64  push];
+processIntXNode:   [makeVarIntX   push];
+processNat8Node:   [makeVarNat8   push];
+processNat16Node:  [makeVarNat16  push];
+processNat32Node:  [makeVarNat32  push];
+processNat64Node:  [makeVarNat64  push];
+processNatXNode:   [makeVarNatX   push];
+processReal32Node: [makeVarReal32 push];
+processReal64Node: [makeVarReal64 push];
 
 addDebugLocationForLastInstruction: [
   processor.options.debug [
@@ -2195,17 +2195,17 @@ addDebugLocationForLastInstruction: [
       locationIndex @operation.cat
     ] when
   ] when
-] func;
+];
 
 addCodeNode: [
   CodeNode owner @processor.@nodes.pushBack
   processor.nodeCount 1 + @processor.@nodeCount set
-] func;
+];
 
 argAbleToCopy: [
   arg:;
   arg.mutable not [arg isTinyArg] &&
-] func;
+];
 
 callInit: [
   copy refToVar:;
@@ -2265,7 +2265,7 @@ callInit: [
       ] &&
     ] loop
   ] when
-] func;
+];
 
 callAssign: [
   refToDst:;
@@ -2338,7 +2338,7 @@ callAssign: [
       ] &&
     ] loop
   ] when
-] func;
+];
 
 callDie: [
   copy refToVar:;
@@ -2385,7 +2385,7 @@ callDie: [
       ] &&
     ] loop
   ] when
-] func;
+];
 
 killStruct: [
   refToVar:;
@@ -2393,7 +2393,7 @@ killStruct: [
   VarStruct refToVar getVar.data.get.get.unableToDie not [
     refToVar callDie
   ] when
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -2457,7 +2457,7 @@ killStruct: [
 
 processNode: [
   astNode indexOfAstNode multiParserResult @currentNode indexOfNode @processor @processorResult processNodeImpl
-] func;
+];
 
 addNamesFromModule: [
   copy moduleId:;
@@ -2473,7 +2473,7 @@ addNamesFromModule: [
       current.nameInfo current.refToVar NameCaseFromModule addNameInfo #it is not own local variable
     ] each
   ] when
-] func;
+];
 
 processUseModule: [
   copy asUse:;
@@ -2505,7 +2505,7 @@ processUseModule: [
       ] when
     ] if
   ] each
-] func;
+];
 
 finalizeListNode: [
   struct: Struct;
@@ -2561,7 +2561,7 @@ finalizeListNode: [
     @currentNode.@stack.clear
     refToStruct @currentNode.@stack.pushBack
   ] when
-] func;
+];
 
 finalizeObjectNode: [
   refToStruct: @currentNode.@struct move owner VarStruct createVariable;
@@ -2596,7 +2596,7 @@ finalizeObjectNode: [
   ] when
 
   refToStruct @currentNode.@stack.pushBack
-] func;
+];
 
 unregCodeNodeNames: [
   #currentNode.parent 0 = not [ # if parent index is 0, it is not node in file, we must save names
@@ -2607,7 +2607,7 @@ unregCodeNodeNames: [
       #("unreg " nameWithOverload.nameInfo processor.nameInfos.at.name) addLog
       nameWithOverload.nameOverload nameWithOverload.nameInfo deleteNameInfoWithOverload
     ] each
-  ] func;
+  ];
 
   #("unreg label names") addLog
   @currentNode.@labelNames unregisterNamesIn
@@ -2648,7 +2648,7 @@ unregCodeNodeNames: [
   @currentNode.@captureTable.release
   @currentNode.@fieldCaptureTable.release
   #] when
-] func;
+];
 
 checkPreStackDepth: [
   newMinStackDepth: getStackDepth currentNode.stack.dataSize -;
@@ -2664,7 +2664,7 @@ checkPreStackDepth: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 deleteNode: [
   copy nodeIndex:;
@@ -2687,13 +2687,13 @@ deleteNode: [
   #  ] when
   #] each
   processor.deletedNodeCount 1 + @processor.@deletedNodeCount set
-] func;
+];
 
 clearRecursionStack: [
   processor.recursiveNodesStack.getSize 0 > [processor.recursiveNodesStack.last indexOfNode =] && [
     @processor.@recursiveNodesStack.popBack
   ] when
-] func;
+];
 
 checkRecursionOfCodeNode: [
   clearBuildingMatchingInfo: FALSE dynamic;
@@ -2728,7 +2728,7 @@ checkRecursionOfCodeNode: [
     @currentNode.@program.clear
     @currentNode.@stack.clear
     TRUE @clearBuildingMatchingInfo set
-  ] func;
+  ];
 
   approvePrevNodes: [
     #check recursion stack state
@@ -2775,7 +2775,7 @@ checkRecursionOfCodeNode: [
       ] &&
     ] loop
     #recursion successful
-  ] func;
+  ];
 
 
   currentNode.state NodeStateNew = [
@@ -2813,7 +2813,7 @@ checkRecursionOfCodeNode: [
             se2: refToVar2 noMatterToCopy [refToVar2][refToVar2 getVar.shadowEnd] if;
             [se1.hostId 0 < not [se2.hostId 0 < not] &&] "variables has no shadowEnd!" assert
             se1 se2 compareEntriesRec
-          ] func;
+          ];
 
           #compare inputs
           result [
@@ -2929,7 +2929,7 @@ checkRecursionOfCodeNode: [
     MatchingInfo @currentNode.@buildingMatchingInfo set
     0            @currentNode.@lastLambdaName set
   ] when
-] func;
+];
 
 makeCompilerPosition: [
   astNode:;
@@ -2942,7 +2942,7 @@ makeCompilerPosition: [
   astNode.token      @result.@token set
 
   result
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -3004,7 +3004,7 @@ makeCompilerPosition: [
     ] [
       refToVar copy FALSE
     ] if
-  ] func;
+  ];
 
   addArg: [
     copy asCopy:;
@@ -3066,12 +3066,12 @@ makeCompilerPosition: [
     ] when
 
     TRUE @hasEffect set
-  ] func;
+  ];
 
-  addCopyArg: [FALSE TRUE addArg] func;
-  addRetArg: [-1 dynamic TRUE TRUE addArg] func;
-  addRefArg: [copy output:; -1 dynamic output FALSE addArg] func;
-  addOutputArg: [TRUE dynamic addRefArg] func;
+  addCopyArg: [FALSE TRUE addArg];
+  addRetArg: [-1 dynamic TRUE TRUE addArg];
+  addRefArg: [copy output:; -1 dynamic output FALSE addArg];
+  addOutputArg: [TRUE dynamic addRefArg];
 
   addVirtualOutput: [
     copy refToVar:;
@@ -3095,7 +3095,7 @@ makeCompilerPosition: [
       TRUE @var.@usedInHeader set
       refToVar markAsUnableToDie
     ] when
-  ] func;
+  ];
 
   callDestructors: [
     currentNode.parent 0 = [
@@ -3130,7 +3130,7 @@ makeCompilerPosition: [
       @retInstruction move @currentNode.@program.pushBack
       FALSE retInstructionIndex @currentNode.@program.at.@enabled set
     ] if
-  ] func;
+  ];
 
   isDeclaration:
   currentNode.nodeCase NodeCaseDeclaration =
@@ -3318,7 +3318,7 @@ makeCompilerPosition: [
         i 1 + @i set TRUE
       ] &&
     ] loop
-  ] func;
+  ];
 
   noname: hasForcedSignature not;
   #[currentNode.nodeCase NodeCaseLambda =] ||;
@@ -3341,7 +3341,7 @@ makeCompilerPosition: [
       current: .@value;
       current.refToVar noMatterToCopy not [current.refToVar getVar.shadowBegin @current.@refToVar set] when
     ] each
-  ] func;
+  ];
 
   @currentNode.@buildingMatchingInfo.@inputs fixArrShadows
   @currentNode.@buildingMatchingInfo.@captures fixArrShadows
@@ -3455,7 +3455,7 @@ makeCompilerPosition: [
     nameInfo: functionName findNameInfo;
     nameInfo @declarationNode.@varNameInfo set
     nameInfo refToVar NameCaseLocal addNameInfo
-  ] func;
+  ];
 
   #generate function header
   noname [processorResult.findModuleFail copy] || [
@@ -3587,7 +3587,7 @@ makeCompilerPosition: [
 
 finalizeCodeNode: [
   compilerPositionInfo forcedSignature multiParserResult @currentNode indexOfNode @processor @processorResult finalizeCodeNodeImpl
-] func;
+];
 
 addIndexArrayToProcess: [
   indexArray:;
@@ -3601,7 +3601,7 @@ addIndexArrayToProcess: [
       TRUE
     ] &&
   ] loop
-] func;
+];
 
 addMatchingNode: [
   copy indexOfNode:;
@@ -3615,12 +3615,12 @@ addMatchingNode: [
     indexOfNode @tableValue.pushBack
     addr @tableValue move @processor.@matchingNodes.insert
   ] if
-] func;
+];
 
 nodeHasCode: [
   node:;
   node.emptyDeclaration not [node.empty not] && [node.deleted not] && [node.nodeCase NodeCaseCodeRefDeclaration = not] &&
-] func;
+];
 
 {
   signature: CFunctionSignature Cref;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1857,9 +1857,10 @@ copyVarImpl: [
 
 copyOneVar: [FALSE dynamic copyOneVarWith];
 
-copyVar:          [FALSE FALSE dynamic copyVarImpl]; #fromchild is static arg
-copyVarFromChild: [TRUE  FALSE dynamic copyVarImpl];
-copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
+copyVar:           [FALSE FALSE dynamic copyVarImpl]; #fromchild is static arg
+copyVarFromChild:  [TRUE  FALSE dynamic copyVarImpl];
+copyVarToNew:      [FALSE TRUE  dynamic copyVarImpl];
+copyVarFromParent: [TRUE  FALSE dynamic copyVarImpl];
 
 {
   dynamicStoraged: Cond;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -884,6 +884,7 @@ createNamedVariable: [
   compilable [
     newRefToVar: refToVar copy;
     staticness: refToVar staticnessOfVar;
+    var: newRefToVar getVar;
 
     #(
     #  "create label " nameInfo processor.nameInfos.at.name
@@ -895,7 +896,11 @@ createNamedVariable: [
     currentNode.nextLabelIsVirtual [
       refToVar isVirtual not [
         staticness Dynamic > not ["value for virtual label must me static" makeStringView compilerError] when
-        staticness Weak    =     [Static refToVar getVar.@staticness set] when
+        staticness Weak    =     [Static @var.@staticness set] when
+      ] when
+
+      var.data.getTag VarImport = [
+        "funcPtr is always pointer, cannot make it virtual" makeStringView compilerError
       ] when
     ] when
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -993,6 +993,7 @@ makeVirtualVarReal: [
       FALSE @result.@mutable set
       result @realValue set
     ] when
+
     realValue copy
   ] if
 ] func;
@@ -2832,8 +2833,9 @@ finalizeCodeNode: [
       current: i currentNode.buildingMatchingInfo.captures.at;
       current.argCase ArgRef = [
         isRealFunction [
-          ("real function can not have local capture; name=" current.nameInfo processor.nameInfos.at.name) assembleString compilerError
+          ("real function can not have local capture; name=" current.nameInfo processor.nameInfos.at.name "; type=" current.refToVar getMplType) assembleString compilerError
         ] when
+
         current.refToVar FALSE addRefArg
       ] [
         current.argCase ArgGlobal = [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -899,7 +899,7 @@ makeVirtualVarReal: [
         refToVar @unfinishedSrc.pushBack
         result @unfinishedDst.pushBack
 
-        result untemporize
+        # result untemporize
         # first pass: make new variable type
         [
           unfinishedSrc.dataSize 0 > [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1910,7 +1910,7 @@ copyVarFromParent: [TRUE  FALSE dynamic copyVarImpl];
       beginVar: begin getVar;
       endVar: end getVar;
       global: refToVar isGlobal;
-      
+
       var.storageStaticness @beginVar.@storageStaticness set
       var.storageStaticness   @endVar.@storageStaticness set
 

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1900,9 +1900,11 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
     headVar: head getVar;
 
     reallyCreateShadows: [
-      refToVar copyOneVar @begin set
-      refToVar copyOneVar @end set
+      shadowSrc: headVar.capturedTail copy;
+      refToVar.mutable @shadowSrc.@mutable set
 
+      shadowSrc copyOneVar @begin set
+      shadowSrc copyOneVar @end set
 
       beginVar: begin getVar;
       endVar: end getVar;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -904,7 +904,10 @@ createNamedVariable: [
       ] when
     ] when
 
-    var: newRefToVar getVar;
+    var.temporary [currentNode.nextLabelIsVirtual not] && [refToVar isGlobal] && [
+      refToVar makeVarTreeDirty
+      Dirty @staticness set
+    ] when
 
     var.temporary currentNode.nextLabelIsSchema not and [
       staticness @var.@staticness set
@@ -1874,13 +1877,6 @@ copyVarToNew:     [FALSE TRUE  dynamic copyVarImpl];
         TRUE @beginVar.@global set
         TRUE @endVar.@global set
 
-        headVar.capturedTail.hostId processor.nodes.at.get.parent 0 = # capture directly from global vars
-        [refToVar isVirtual not] &&
-        [processor.processingExport 0 >] &&
-        [var.data.getTag VarImport = not] && [
-          begin Dirty makeStaticness @begin set
-          end   Dirty makeStaticness @end   set
-        ] when
       ] [
         begin unglobalize
         end unglobalize

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3733,6 +3733,7 @@ nodeHasCode: [
     #("started iter for node " indexOfNode "; recState=" currentNode.recursionState) addLog
     createLabel
 
+    0 @currentNode.@countOfUCall set
     @currentNode.@labelNames.clear
     @currentNode.@fromModuleNames.clear
     @currentNode.@captureNames.clear

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -353,7 +353,7 @@ addFuncDebugInfo: [
   funcImplementation: funcName makeStringView getStringImplementation;
 
   (
-    "!" funcDebugIndex " = distinct !DISubprogram(name: \"" funcImplementation makeStringView "\", linkageName: \"" @funcIRName
+    "!" funcDebugIndex " = distinct !DISubprogram(name: \"" funcImplementation "." funcDebugIndex "\", linkageName: \"" @funcIRName
     "\", scope: !" position.fileNumber processor.debugInfo.fileNameIds.at
     ", file: !" position.fileNumber processor.debugInfo.fileNameIds.at ", line: " position.line  ", type: !" subroutineIndex
     ", scopeLine: " position.line ", unit: !" processor.debugInfo.unit ")") assembleString @processor.@debugInfo.@strings.pushBack

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -47,7 +47,7 @@ addDebugProlog: [
   t: "r64" makeStringView 64 "DW_ATE_float" makeStringView addTypeInfo;
   t: "string element" makeStringView 8 "DW_ATE_signed_char" makeStringView addTypeInfo;
   t: "DW_TAG_pointer_type" makeStringView t processor.options.pointerSize 0ix cast 0 cast addDerivedTypeInfo;
-] func;
+];
 
 addLinkerOptionsDebugInfo: [
   index: processor.debugInfo.lastId copy;
@@ -70,7 +70,7 @@ addLinkerOptionsDebugInfo: [
     String @processor.@debugInfo.@strings.pushBack
     String @processor.@debugInfo.@strings.pushBack
   ] if
-] func;
+];
 
 getPlainTypeDebugDeclaration: [
   var: getVar;
@@ -104,7 +104,7 @@ getPlainTypeDebugDeclaration: [
       ] if
     ] if
   ] if
-] func;
+];
 
 getPointerTypeDebugDeclaration: [
   refToVar:;
@@ -113,7 +113,7 @@ getPointerTypeDebugDeclaration: [
   fr: var.mplTypeId @processor.@debugInfo.@typeIdToDbgId.find;
   [fr.success copy] "Pointee has no type debug info!" assert
   "DW_TAG_pointer_type" makeStringView fr.value processor.options.pointerSize 0ix cast 0 cast addDerivedTypeInfo
-] func;
+];
 
 addLinkedLib: [
   libName:;
@@ -121,7 +121,7 @@ addLinkedLib: [
   fr.success not [
     @libName TRUE @processor.@libNames.insert
   ] when
-] func;
+];
 
 addMemberInfo: [
   copy fieldNumber:;
@@ -155,7 +155,7 @@ addMemberInfo: [
 
   offset fsize + @offset set
   index
-] func;
+];
 
 getTypeDebugDeclaration: [
   refToVar:;
@@ -224,7 +224,7 @@ getTypeDebugDeclaration: [
       ] if
     ] if
   ] if
-] func;
+];
 
 addVariableDebugInfo: [
   refToVar:;
@@ -245,7 +245,7 @@ addVariableDebugInfo: [
   ] [
     -1
   ] if
-] func;
+];
 
 addGlobalVariableDebugInfo: [
   refToVar:;
@@ -272,7 +272,7 @@ addGlobalVariableDebugInfo: [
   ] [
     -1
   ] if
-] func;
+];
 
 addVariableMetadata: [
   refToVar:;
@@ -283,14 +283,14 @@ addVariableMetadata: [
     ("  call void @llvm.dbg.declare(metadata " refToVar getIrType "* " refToVar getIrName ", metadata !" localVariableDebugIndex ", metadata !" processor.debugInfo.unit 1 + ")"
     ) assembleString makeInstruction @currentNode.@program.pushBack
   ] when
-] func;
+];
 
 addExpression: [
   index: processor.debugInfo.lastId copy;
   processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
   ("!" index " = !DIExpression()") assembleString @processor.@debugInfo.@strings.pushBack
   index
-] func;
+];
 
 addTypeInfo: [
   encoding:;
@@ -302,7 +302,7 @@ addTypeInfo: [
   ("!" index " = !DIBasicType(name: \"" @name "\", size: " size ", encoding: " @encoding ")") assembleString @processor.@debugInfo.@strings.pushBack
 
   index
-] func;
+];
 
 addDerivedTypeInfo: [
   copy size:;
@@ -313,7 +313,7 @@ addDerivedTypeInfo: [
   ("!" index " = !DIDerivedType(tag: " @tag ", baseType: !" base ", size: " @size ")") assembleString @processor.@debugInfo.@strings.pushBack
 
   index
-] func;
+];
 
 addFileDebugInfo: [
   compileOnce
@@ -325,7 +325,7 @@ addFileDebugInfo: [
   onlyPath: onlyFileName: fullPath simplifyPath;;
   ("!" index " = !DIFile(filename: \"" onlyFileName "\", directory: \"" onlyPath makeStringView getStringImplementation "\")" ) assembleString @processor.@debugInfo.@strings.pushBack
   index
-] func;
+];
 
 addFuncSubroutineInfo: [
   compileOnce
@@ -340,7 +340,7 @@ addFuncSubroutineInfo: [
   ("!" index " = !DISubroutineType(types: !" types ")") assembleString @processor.@debugInfo.@strings.pushBack
 
   index
-] func;
+];
 
 addFuncDebugInfo: [
   compileOnce
@@ -357,7 +357,7 @@ addFuncDebugInfo: [
     "\", scope: !" position.fileNumber processor.debugInfo.fileNameIds.at
     ", file: !" position.fileNumber processor.debugInfo.fileNameIds.at ", line: " position.line  ", type: !" subroutineIndex
     ", scopeLine: " position.line ", unit: !" processor.debugInfo.unit ")") assembleString @processor.@debugInfo.@strings.pushBack
-] func;
+];
 
 addDebugLocation: [
   compileOnce
@@ -371,21 +371,21 @@ addDebugLocation: [
 
   index funcDbgIndex @processor.@debugInfo.@locationIds.insert
   index
-] func;
+];
 
 addDebugReserve: [
   index: processor.debugInfo.lastId copy;
   processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
   String @processor.@debugInfo.@strings.pushBack
   index
-] func;
+];
 
 moveLastDebugString: [
   copy index:;
   processor.debugInfo.strings.last
   index 4 + @processor.@debugInfo.@strings.at set
   @processor.@debugInfo.@strings.popBack
-] func;
+];
 
 correctUnitInfo: [
   copy lastUnit:;
@@ -411,7 +411,7 @@ correctUnitInfo: [
 
   ("!llvm.dbg.cu = !{!" processor.debugInfo.unit "}") assembleString
   processor.debugInfo.cuStringNumber @processor.@debugInfo.@strings.at set
-] func;
+];
 
 clearUnusedDebugInfo: [
   processor.debugInfo.locationIds [
@@ -424,4 +424,4 @@ clearUnusedDebugInfo: [
     ] when
   ] each
 
-] func;
+];

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -142,11 +142,11 @@ addMemberInfo: [
 
   name "" = [
     ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"f" fieldNumber "\", scope: !" currentNode.funcDbgIndex
-      ", file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
+      ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
       ", line: " currentNode.position.line ", baseType: !" fr.value ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
   ] [
     ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"" name "\", scope: !" currentNode.funcDbgIndex
-      ", file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
+      ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
       ", line: " currentNode.position.line ", baseType: !" fr.value ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
   ] if
 
@@ -211,7 +211,7 @@ getTypeDebugDeclaration: [
             index: processor.debugInfo.lastId copy;
             processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
 
-            ("!" index " = distinct !DICompositeType(tag: DW_TAG_structure_type, file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
+            ("!" index " = distinct !DICompositeType(tag: DW_TAG_structure_type, file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
               ", name: \"" refToVar getDebugType "\", line: " currentNode.position.line ", size: " refToVar getStorageSize 0ix cast 0 cast 8 * ", elements: !" index 1 -
               ")") assembleString @processor.@debugInfo.@strings.pushBack
             index currentNode.funcDbgIndex @processor.@debugInfo.@locationIds.insert
@@ -237,7 +237,7 @@ addVariableDebugInfo: [
     index: processor.debugInfo.lastId copy;
     processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
     ("!" index " = !DILocalVariable(name: \"" nameInfo processor.nameInfos.at.name "\", scope: !" currentNode.funcDbgIndex
-      ", file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
+      ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
       ", line: " currentNode.position.line ", type: !" debugDeclarationIndex ")") assembleString @processor.@debugInfo.@strings.pushBack
     index currentNode.funcDbgIndex @processor.@debugInfo.@locationIds.insert
 
@@ -263,7 +263,7 @@ addGlobalVariableDebugInfo: [
     index: processor.debugInfo.lastId copy;
     processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
     ("!" index " = !DIGlobalVariable(name: \"" nameInfo processor.nameInfos.at.name "\", linkageName: \"" refToVar getIrName
-      "\", scope: !" processor.debugInfo.unit ", file: !" currentNode.position.filename processor.debugInfo.fileNameIds.at
+      "\", scope: !" processor.debugInfo.unit ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
       ", line: " currentNode.position.line ", type: !" debugDeclarationIndex ", isLocal: false, isDefinition: true)") assembleString @processor.@debugInfo.@strings.pushBack
 
     result: index 1 -;
@@ -354,8 +354,8 @@ addFuncDebugInfo: [
 
   (
     "!" funcDebugIndex " = distinct !DISubprogram(name: \"" funcImplementation makeStringView "\", linkageName: \"" @funcIRName
-    "\", scope: !" position.filename processor.debugInfo.fileNameIds.at
-    ", file: !" position.filename processor.debugInfo.fileNameIds.at ", line: " position.line  ", type: !" subroutineIndex
+    "\", scope: !" position.fileNumber processor.debugInfo.fileNameIds.at
+    ", file: !" position.fileNumber processor.debugInfo.fileNameIds.at ", line: " position.line  ", type: !" subroutineIndex
     ", scopeLine: " position.line ", unit: !" processor.debugInfo.unit ")") assembleString @processor.@debugInfo.@strings.pushBack
 ] func;
 

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -1,0 +1,155 @@
+"defaultImpl" module
+"control" includeModule
+
+failProcForProcessor: [
+  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr] func;
+  copy message:;
+  "ASSERTION FAILED!!!" print LF print
+  message print LF print
+  "While compiling:" print LF print
+  defaultPrintStackTrace
+
+  "Terminating..." print LF print
+  2 exit
+] func;
+
+defaultFailProc: [
+  text: pop;
+] func;
+
+defaultCall: [
+  refToVar: pop;
+  compilable [
+    var: refToVar getVar;
+    var.data.getTag VarCode = [
+      VarCode var.data.get "call" makeStringView processCall
+    ] [
+      var.data.getTag VarImport = [
+        refToVar processFuncPtr
+      ] [
+        refToVar isCallable [
+          RefToVar refToVar "call" makeStringView callCallableStruct # call struct with INVALID object
+        ] [
+          "not callable" makeStringView compilerError
+        ] if
+      ] if
+    ] if
+  ] when
+] func;
+
+defaultSet: [
+  refToDst: pop;
+  refToSrc: pop;
+
+  compilable [
+    refToDst refToSrc variablesAreSame [
+      refToSrc getVar.data.getTag VarImport = [
+        "functions cannot be copied" compilerError
+      ] [
+        refToDst.mutable [
+          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
+          refToSrc refToDst createCopyToExists
+        ] [
+          "destination is immutable" compilerError
+        ] if
+      ] if
+    ] [
+      refToDst.mutable not [
+        "destination is immutable" compilerError
+      ] [
+        lambdaCastResult: refToSrc refToDst tryImplicitLambdaCast;
+        lambdaCastResult.success [
+          newSrc: lambdaCastResult.refToVar TRUE createRef;
+          newSrc refToDst createCopyToExists
+        ] [
+          ("types mismatch, src is " refToSrc getMplType "," LF "dst is " refToDst getMplType) assembleString compilerError
+        ] if
+      ] if
+    ] if
+  ] when
+] func;
+
+defaultRef: [
+  copy mutable:;
+  refToVar: pop;
+  compilable [
+    refToVar mutable createRef push
+  ] when
+] func;
+
+defaultMakeConstWith: [
+  copy check:;
+  refToVar: pop;
+  compilable [
+    check [refToVar getVar.temporary copy] && [
+      "temporary objects cannot be set const" compilerError
+    ] [
+      FALSE @refToVar.@mutable set
+      refToVar push
+    ] if
+  ] when
+] func;
+
+defaultUseOrIncludeModule: [
+  copy asUse:;
+  (
+    [compilable]
+    [currentNode.parent  0 = not ["module can be used only in top node" compilerError] when]
+    [refToName: pop;]
+    [refToName staticnessOfVar Weak < ["name must be static string" compilerError] when]
+    [
+      varName: refToName getVar;
+      varName.data.getTag VarString = not ["name must be static string" compilerError] when
+    ] [
+      string: VarString varName.data.get;
+      fr: string makeStringView processor.modules.find;
+      fr.success [fr.value 0 < not] && [
+        frn: fr.value currentNode.usedModulesTable.find;
+        frn2: fr.value currentNode.directlyIncludedModulesTable.find;
+        frn.success frn2.success or [
+          ("duplicate use module: " string) assembleString compilerError
+        ] [
+          fr.value asUse processUseModule
+        ] if
+      ] [
+        TRUE dynamic @processorResult.@findModuleFail set
+        string @processorResult.@errorInfo.@missedModule set
+        ("module not found: " string) assembleString compilerError
+      ] if
+    ]
+  ) sequence
+] func;
+
+defaultPrintStack: [
+  ("stack:" LF "depth=" getStackDepth LF) printList
+
+  i: 0 dynamic;
+  [
+    i getStackDepth < [
+      entry: i getStackEntryUnchecked;
+      (i getStackEntryUnchecked getMplType entry.mutable ["R" makeStringView]["C" makeStringView] if LF) printList
+      i 1 + @i set TRUE
+    ] &&
+  ] loop
+] func;
+
+defaultPrintStackTrace: [
+  nodeIndex: indexOfNode copy;
+  [
+    node: nodeIndex processor.nodes.at.get;
+    node.root [
+      FALSE
+    ] [
+      ("at filename: "  node.position.filename processor.options.fileNames.at
+        ", token: "      node.position.token
+        ", nodeIndex: "  nodeIndex
+        ", line: "       node.position.line
+        ", column: "     node.position.column LF) printList
+
+      node.parent @nodeIndex set
+      TRUE
+    ] if
+  ] loop
+
+  defaultPrintStack
+] func;

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -42,6 +42,9 @@ defaultSet: [
   refToSrc: pop;
 
   compilable [
+    refToSrc makeVarRealCaptured
+    refToDst makeVarRealCaptured
+
     refToDst refToSrc variablesAreSame [
       refToSrc getVar.data.getTag VarImport = [
         "functions cannot be copied" compilerError

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -2,7 +2,7 @@
 "control" includeModule
 
 failProcForProcessor: [
-  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr] func;
+  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr];
   copy message:;
   "ASSERTION FAILED!!!" print LF print
   message print LF print
@@ -11,11 +11,11 @@ failProcForProcessor: [
 
   "Terminating..." print LF print
   2 exit
-] func;
+];
 
 defaultFailProc: [
   text: pop;
-] func;
+];
 
 defaultCall: [
   refToVar: pop;
@@ -35,7 +35,7 @@ defaultCall: [
       ] if
     ] if
   ] when
-] func;
+];
 
 defaultSet: [
   refToDst: pop;
@@ -67,7 +67,7 @@ defaultSet: [
       ] if
     ] if
   ] when
-] func;
+];
 
 defaultRef: [
   copy mutable:;
@@ -75,7 +75,7 @@ defaultRef: [
   compilable [
     refToVar mutable createRef push
   ] when
-] func;
+];
 
 defaultMakeConstWith: [
   copy check:;
@@ -88,7 +88,7 @@ defaultMakeConstWith: [
       refToVar push
     ] if
   ] when
-] func;
+];
 
 defaultUseOrIncludeModule: [
   copy asUse:;
@@ -118,7 +118,7 @@ defaultUseOrIncludeModule: [
       ] if
     ]
   ) sequence
-] func;
+];
 
 getStackEntryWith: [
   copy check:;
@@ -145,10 +145,10 @@ getStackEntryWith: [
     ] if
   ] loop
   @result
-] func;
+];
 
-getStackEntry:          [compileOnce TRUE  static getStackEntryWith] func;
-getStackEntryUnchecked: [            FALSE static getStackEntryWith] func;
+getStackEntry:          [compileOnce TRUE  static getStackEntryWith];
+getStackEntryUnchecked: [            FALSE static getStackEntryWith];
 
 getStackDepth: [
   depth: 0 dynamic;
@@ -167,7 +167,7 @@ getStackDepth: [
   [inputsCount depth > not] "Missed stack overflow!" assert
 
   depth inputsCount -
-] func;
+];
 
 defaultPrintStack: [
   ("stack:" LF "depth=" getStackDepth LF) printList
@@ -180,7 +180,7 @@ defaultPrintStack: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 defaultPrintStackTrace: [
   nodeIndex: indexOfNode copy;
@@ -201,7 +201,7 @@ defaultPrintStackTrace: [
   ] loop
 
   defaultPrintStack
-] func;
+];
 
 findNameInfo: [
   key:;
@@ -220,4 +220,4 @@ findNameInfo: [
 
     result
   ] if
-] func;
+];

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -22,7 +22,7 @@ defaultCall: [
   compilable [
     var: refToVar getVar;
     var.data.getTag VarCode = [
-      VarCode var.data.get "call" makeStringView processCall
+      VarCode var.data.get.index "call" makeStringView processCall
     ] [
       var.data.getTag VarImport = [
         refToVar processFuncPtr

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -111,7 +111,7 @@ getStringImplementation: [
     i: 0 dynamic;
     [
       i stringView.dataSize < [
-        codeRef: stringView.dataBegin storageAddress i 0ix cast 0nx cast + Nat8 addressToReference;
+        codeRef: stringView.dataBegin storageAddress i Natx cast + Nat8 addressToReference;
         code: codeRef copy;
         code 32n8 < not [code 127n8 <] && [code 34n8 = not] && [code 92n8 = not] && [  # exclude " and \
           code 0n32 cast @result.catSymbolCode

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -133,9 +133,9 @@ createStringTypeByStringName: [
   ("%type." stringNameNoFirst) assembleString
 ];
 
-createStringIR: [
+createStringIRNoAlloc: [
   refToVar:;
-  var: refToVar createAllocIR getVar;
+  var: refToVar getVar;
   varValue: VarString var.data.get;
   stringSizeWithZero: varValue.chars.dataSize 0 = [1][varValue.chars.dataSize 0 cast] if;
 
@@ -167,6 +167,10 @@ createStringIR: [
   ) assembleString makeInstruction @currentNode.@program.pushBack
 
   refToVar copy
+];
+
+createStringIR: [
+  createAllocIR createStringIRNoAlloc
 ];
 
 createGetTextSizeIR: [

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -7,19 +7,19 @@ IRArgument: [{
   irTypeId: 0;
   irNameId: 0;
   byRef: TRUE;
-}] func;
+}];
 
 createDerefTo: [
   derefNameId:;
   refToVar:;
   ("  " @derefNameId getNameById " = load " refToVar getIrType ", " refToVar getIrType "* " refToVar getIrName) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createDerefToRegister: [
   derefName: generateRegisterIRName;
   derefName createDerefTo
   derefName
-] func;
+];
 
 createAllocIR: [
   refToVar:;
@@ -35,7 +35,7 @@ createAllocIR: [
   ] if
 
   refToVar copy
-] func;
+];
 
 createStaticInitIR: [
   refToVar:;
@@ -44,7 +44,7 @@ createStaticInitIR: [
   (refToVar getIrName " = local_unnamed_addr global " refToVar getStaticStructIR) assembleString @processor.@prolog.pushBack
   processor.prolog.dataSize 1 - @var.@globalDeclarationInstructionIndex set
   refToVar copy
-] func;
+];
 
 createVarImportIR: [
   refToVar:;
@@ -55,7 +55,7 @@ createVarImportIR: [
   processor.prolog.dataSize 1 - @var.@globalDeclarationInstructionIndex set
 
   refToVar copy
-] func;
+];
 
 createVarExportIR: [
   refToVar:;
@@ -66,28 +66,28 @@ createVarExportIR: [
   processor.prolog.dataSize 1 - @var.@globalDeclarationInstructionIndex set
 
   refToVar copy
-] func;
+];
 
 createAliasIR: [
   aliaseeType:;
   aliasee:;
   alias:;
   ("  " alias getNameById " = alias " aliaseeType getNameById ", " aliaseeType getNameById "* " aliasee getNameById) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createGlobalAliasIR: [
   aliaseeType:;
   aliasee:;
   alias:;
   (alias getNameById " = alias " aliaseeType getNameById ", " aliaseeType getNameById "* " aliasee getNameById) assembleString @processor.@prolog.pushBack
-] func;
+];
 
 createFuncAliasIR: [
   aliaseeType:;
   aliasee:;
   alias:;
   (alias " = ifunc " aliaseeType ", " aliaseeType "* " aliasee) assembleString
-] func;
+];
 
 createStoreConstant: [
   refToDst:;
@@ -95,14 +95,14 @@ createStoreConstant: [
 
   s: refWithValue getPlainConstantIR;
   ("  store " refToDst getIrType " " s ", " refToDst getIrType "* " refToDst getIrName) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createPlainIR: [
   refToVar:;
   [refToVar isPlain] "Var is not plain" assert
   refToVar refToVar createAllocIR createStoreConstant
   refToVar copy
-] func;
+];
 
 getStringImplementation: [
   stringView: makeStringView;
@@ -125,13 +125,13 @@ getStringImplementation: [
     ] loop
     result
   ] call
-] func;
+];
 
 createStringTypeByStringName: [
   stringName: makeStringView;
   stringNameNoFirst: stringName.getTextSize 1 - stringName.dataBegin storageAddress 1nx + Nat8 addressToReference makeStringViewRaw;
   ("%type." stringNameNoFirst) assembleString
-] func;
+];
 
 createStringIR: [
   refToVar:;
@@ -167,7 +167,7 @@ createStringIR: [
   ) assembleString makeInstruction @currentNode.@program.pushBack
 
   refToVar copy
-] func;
+];
 
 createGetTextSizeIR: [
   refToDst:;
@@ -205,13 +205,13 @@ createGetTextSizeIR: [
     1 createJump
     createLabel
   ] when
-] func;
+];
 
 createTypeDeclaration: [
   irType:;
   alias:;
   (@alias " = type " @irType) assembleString @processor.@prolog.pushBack
-] func;
+];
 
 createStaticGEP: [
   structRefToVar:;
@@ -222,7 +222,7 @@ createStaticGEP: [
   realIndex: index VarStruct struct.data.get.get.realFieldIndexes.at;
   ("  " resultRefToVar getIrName " = getelementptr " structRefToVar getIrType ", " structRefToVar getIrType "* " structRefToVar getIrName ", i32 0, i32 " realIndex
   ) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createFailWithMessage: [
   message:;
@@ -239,7 +239,7 @@ createFailWithMessage: [
     failProcRefToVar derefAndPush
     defaultCall
   ] if
-] func;
+];
 
 createDynamicGEP: [
   structRefToVar:;
@@ -265,7 +265,7 @@ createDynamicGEP: [
   ("  " resultRefToVar getIrName " = getelementptr " structRefToVar getIrType ", " structRefToVar getIrType "* " structRefToVar  getIrName ", i32 0, i32 " indexRegister getNameById
   ) assembleString makeInstruction @currentNode.@program.pushBack
 
-] func;
+];
 
 createGEPInsteadOfAlloc: [
   struct:;
@@ -284,7 +284,7 @@ createGEPInsteadOfAlloc: [
 
   dstVar.allocationInstructionIndex @dstVar.@getInstructionIndex set
   -1 @dstVar.@allocationInstructionIndex set
-] func;
+];
 
 createStoreFromRegister: [
   destRefToVar:;
@@ -292,7 +292,7 @@ createStoreFromRegister: [
 
   resultVar: destRefToVar getVar;
   ("  store " destRefToVar getIrType " " @regName getNameById ", " destRefToVar getIrType "* " destRefToVar getIrName) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createBinaryOperation: [
   opName:;
@@ -302,7 +302,7 @@ createBinaryOperation: [
   resultReg: generateRegisterIRName;
   ("  " resultReg getNameById " = " @opName " " arg1 getIrType " " var1p getNameById ", " var2p getNameById) assembleString makeInstruction @currentNode.@program.pushBack
   resultReg result createStoreFromRegister
-] func;
+];
 
 createBinaryOperationDiffTypes: [
   opName:;
@@ -321,7 +321,7 @@ createBinaryOperationDiffTypes: [
   resultReg: generateRegisterIRName;
   ("  " resultReg getNameById " = " opName " " arg1 getIrType " " var1p getNameById ", " castedReg getNameById) assembleString makeInstruction @currentNode.@program.pushBack
   resultReg result createStoreFromRegister
-] func;
+];
 
 createDirectBinaryOperation: [
   opName:;
@@ -331,7 +331,7 @@ createDirectBinaryOperation: [
   resultReg: generateRegisterIRName;
   ("  " resultReg getNameById " = " opName " " arg1 getIrType "* " arg1 getIrName ", " arg2 getIrName) assembleString makeInstruction @currentNode.@program.pushBack
   resultReg result createStoreFromRegister
-] func;
+];
 
 createUnaryOperation: [
   mopName:;
@@ -341,7 +341,7 @@ createUnaryOperation: [
   resultReg: generateRegisterIRName;
   ("  " resultReg getNameById " = " opName " " arg getIrType " " mopName varp getNameById) assembleString makeInstruction @currentNode.@program.pushBack
   resultReg result createStoreFromRegister
-] func;
+];
 
 createMemset: [
   dstRef:;
@@ -351,7 +351,7 @@ createMemset: [
     loadReg: srcRef createDerefToRegister;
     loadReg dstRef createStoreFromRegister
   ] when
-] func;
+];
 
 createCheckedCopyToNewWith: [
   copy doDie:;
@@ -387,10 +387,10 @@ createCheckedCopyToNewWith: [
     loadReg: srcRef createDerefToRegister;
     loadReg dstRef createStoreFromRegister
   ] if
-] func;
+];
 
-createCheckedCopyToNew: [TRUE dynamic createCheckedCopyToNewWith] func;
-createCheckedCopyToNewNoDie: [FALSE dynamic createCheckedCopyToNewWith] func;
+createCheckedCopyToNew: [TRUE dynamic createCheckedCopyToNewWith];
+createCheckedCopyToNewNoDie: [FALSE dynamic createCheckedCopyToNewWith];
 
 createCopyToNew: [
   newRefToVar:;
@@ -400,7 +400,7 @@ createCopyToNew: [
   ] [
     newRefToVar createAllocIR createCheckedCopyToNew
   ] if
-] func;
+];
 
 createCastCopyToNew: [
   castName:;
@@ -412,7 +412,7 @@ createCastCopyToNew: [
   ("  " castedReg getNameById " = " @castName " " srcRef getIrType " " loadReg getNameById " to " dstRef getIrType) assembleString makeInstruction @currentNode.@program.pushBack
 
   castedReg dstRef createStoreFromRegister
-] func;
+];
 
 createCastCopyPtrToNew: [
   castName:;
@@ -423,7 +423,7 @@ createCastCopyPtrToNew: [
   ("  " castedReg getNameById " = " @castName " " srcRef getIrType "* " srcRef getIrName " to " dstRef getIrType) assembleString makeInstruction @currentNode.@program.pushBack
 
   castedReg dstRef createStoreFromRegister
-] func;
+];
 
 createCopyToExists: [
   dstRef:;
@@ -455,19 +455,19 @@ createCopyToExists: [
   ] [
     srcRef dstRef createMemset
   ] if
-] func;
+];
 
 createRefOperation: [
   dstRef: createAllocIR;
   srcRef:;
   srcRef getVar.irNameId dstRef createStoreFromRegister
-] func;
+];
 
 createRetValue: [
   refToVar:;
   getReg: refToVar createDerefToRegister;
   ("  ret " refToVar getIrType " " getReg getNameById) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createCallIR: [
   funcName:;
@@ -511,12 +511,12 @@ createCallIR: [
   addDebugLocationForLastInstruction
 
   retName
-] func;
+];
 
 createLabel: [
   ("label" currentNode.lastBrLabelName ":") assembleString makeInstruction @currentNode.@program.pushBack
   currentNode.lastBrLabelName 1 + @currentNode.@lastBrLabelName set
-] func;
+];
 
 createBranch: [
   refToCond:;
@@ -525,13 +525,13 @@ createBranch: [
   condReg: refToCond createDerefToRegister;
   ("  br i1 " condReg getNameById ", label %label" currentNode.lastBrLabelName timeShift - ", label %label" currentNode.lastBrLabelName timeShift - 1 +
   ) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createJump: [
   copy timeShift:;
 
   ("  br label %label" currentNode.lastBrLabelName timeShift - 1 +) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createPhiNode: [
   copy shift:;
@@ -542,7 +542,7 @@ createPhiNode: [
 
   ("  " @varName " = phi " @varType " [ " @thenName ", %label" currentNode.lastBrLabelName 3 - shift + " ], [ " @elseName ", %label" currentNode.lastBrLabelName 2 - shift + " ]"
   ) assembleString makeInstruction @currentNode.@program.pushBack
-] func;
+];
 
 createComent: [
   coment: makeStringView;
@@ -550,11 +550,11 @@ createComent: [
     compileOnce
     (" ;" coment) assembleString makeInstruction @currentNode.@program.pushBack
   ] call
-] func;
+];
 
 addStrToProlog: [
   toString @processor.@prolog.pushBack
-] func;
+];
 
 createNew: [
   refToVar:;
@@ -580,7 +580,7 @@ createNew: [
 
   ptrVar markAsUnableToDie
   ptrVar
-] func;
+];
 
 createDelete: [
   refToVar:;
@@ -597,7 +597,7 @@ createDelete: [
     ("  " ptrName getNameById " = ptrtoint " refToVar getIrType "* " refToVar getIrName  " to i32") assembleString makeInstruction @currentNode.@program.pushBack
     ("  call void @free(i32 " ptrName getNameById ")" ) assembleString makeInstruction @currentNode.@program.pushBack
   ] if
-] func;
+];
 
 createFloatBuiltins: [
   "declare float @llvm.sin.f32(float)"           addStrToProlog
@@ -616,7 +616,7 @@ createFloatBuiltins: [
   "declare double @llvm.log10.f64(double)"       addStrToProlog
   "declare float @llvm.pow.f32(float, float)"    addStrToProlog
   "declare double @llvm.pow.f64(double, double)" addStrToProlog
-] func;
+];
 
 createHeapBuiltins: [
   "malloc" @processor.@namedFunctions.find.success not [
@@ -634,7 +634,7 @@ createHeapBuiltins: [
       "declare void @free(i32)" addStrToProlog
     ] if
   ] when
-] func;
+];
 
 createCtors: [
   "" addStrToProlog
@@ -647,7 +647,7 @@ createCtors: [
   ] each
   "  ret void" addStrToProlog
   "}" addStrToProlog
-] func;
+];
 
 createDtors: [
   "" addStrToProlog
@@ -660,7 +660,7 @@ createDtors: [
   ] each
   "  ret void" addStrToProlog
   "}" addStrToProlog
-] func;
+];
 
 sortInstructions: [
   allocs:             Instruction Array;
@@ -689,7 +689,7 @@ sortInstructions: [
   @fakePointersAllocs [.@value move @currentNode.@program.pushBack] each
   @fakePointers       [.@value move @currentNode.@program.pushBack] each
   @noallocs           [.@value move @currentNode.@program.pushBack] each
-] func;
+];
 
 addAliasesForUsedNodes: [
   String @processor.@prolog.pushBack
@@ -700,4 +700,4 @@ addAliasesForUsedNodes: [
       @currentNode.@aliases [.@value move @processor.@prolog.pushBack] each
     ] when
   ] each
-] func;
+];

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -1,5 +1,7 @@
 "irWriter" module
-"control" useModule
+
+"control" includeModule
+"defaultImpl" includeModule
 
 IRArgument: [{
   irTypeId: 0;
@@ -232,10 +234,10 @@ createFailWithMessage: [
 
   failProcRefToVar getVar.data.getTag VarBuiltin = [
     #no overload
-    mplBuiltinFailProc
+    defaultFailProc
   ] [
     failProcRefToVar derefAndPush
-    mplBuiltinCall
+    defaultCall
   ] if
 ] func;
 

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -556,49 +556,6 @@ addStrToProlog: [
   toString @processor.@prolog.pushBack
 ];
 
-createNew: [
-  refToVar:;
-
-  addrName: generateRegisterIRName;
-  processor.options.pointerSize 64nx = [
-    ("  " addrName getNameById " = call i64 @malloc(i64 " refToVar getStorageSize ")") assembleString makeInstruction @currentNode.@program.pushBack
-  ] [
-    ("  " addrName getNameById " = call i32 @malloc(i32 " refToVar getStorageSize ")") assembleString makeInstruction @currentNode.@program.pushBack
-  ] if
-
-  ptrVar: refToVar copyVar;
-  TRUE @ptrVar.@mutable set
-  currentNode.program.dataSize ptrVar getVar.@getInstructionIndex set
-
-  processor.options.pointerSize 64nx = [
-    ("  " ptrVar getIrName " = inttoptr i64 " addrName getNameById " to " ptrVar getIrType "*") assembleString makeInstruction @currentNode.@program.pushBack
-  ] [
-    ("  " ptrVar getIrName " = inttoptr i32 " addrName getNameById " to " ptrVar getIrType "*") assembleString makeInstruction @currentNode.@program.pushBack
-  ] if
-
-  refToVar ptrVar createCheckedCopyToNew
-
-  ptrVar markAsUnableToDie
-  ptrVar
-];
-
-createDelete: [
-  refToVar:;
-
-  refToVar callDie
-
-  ptrName: generateRegisterIRName;
-  castOp: String;
-
-  processor.options.pointerSize 64nx = [
-    ("  " ptrName getNameById " = ptrtoint " refToVar getIrType "* " refToVar getIrName  " to i64") assembleString makeInstruction @currentNode.@program.pushBack
-    ("  call void @free(i64 " ptrName getNameById ")" ) assembleString makeInstruction @currentNode.@program.pushBack
-  ] [
-    ("  " ptrName getNameById " = ptrtoint " refToVar getIrType "* " refToVar getIrName  " to i32") assembleString makeInstruction @currentNode.@program.pushBack
-    ("  call void @free(i32 " ptrName getNameById ")" ) assembleString makeInstruction @currentNode.@program.pushBack
-  ] if
-];
-
 createFloatBuiltins: [
   "declare float @llvm.sin.f32(float)"           addStrToProlog
   "declare double @llvm.sin.f64(double)"         addStrToProlog
@@ -616,24 +573,6 @@ createFloatBuiltins: [
   "declare double @llvm.log10.f64(double)"       addStrToProlog
   "declare float @llvm.pow.f32(float, float)"    addStrToProlog
   "declare double @llvm.pow.f64(double, double)" addStrToProlog
-];
-
-createHeapBuiltins: [
-  "malloc" @processor.@namedFunctions.find.success not [
-    processor.options.pointerSize 64nx = [
-      "declare i64 @malloc(i64)" addStrToProlog
-    ] [
-      "declare i32 @malloc(i32)" addStrToProlog
-    ] if
-  ] when
-
-  "free" @processor.@namedFunctions.find.success not [
-    processor.options.pointerSize 64nx = [
-      "declare void @free(i64)" addStrToProlog
-    ] [
-      "declare void @free(i32)" addStrToProlog
-    ] if
-  ] when
 ];
 
 createCtors: [

--- a/main.mpl
+++ b/main.mpl
@@ -30,8 +30,9 @@ addToProcess: [
   fileText:;
   copy fileNumber:;
   fileName:;
+  parserResult: ParserResult;
 
-  parserResult: fileText fileNumber parseString;
+  @parserResult fileText makeStringView fileNumber parseString
 
   parserResult.success [
     @parserResult optimizeLabels
@@ -247,7 +248,7 @@ createDefinition: [
                     pair:;
                     i: pair.index;
                     nodePosition: pair.value;
-                    (nodePosition.filename options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
+                    (nodePosition.fileNumber options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
 
                     i 0 = [
                       ("error, [" nodePosition.token "], " current.message LF) printList

--- a/main.mpl
+++ b/main.mpl
@@ -230,32 +230,35 @@ createDefinition: [
 
             processorResult.success [
               outputFileName @processorResult.@program saveString [
-                ("program written to " makeStringView outputFileName makeStringView) addLog
+                ("program written to " outputFileName) addLog
               ] [
-                ("failed to save program" makeStringView) addLog
+                ("failed to save program" LF) printList
+                FALSE @success set
               ] if
             ] [
-              processorResult.errorInfo.position.dataSize 0 = [
-                ("error, "  processorResult.errorInfo.message) printList LF print
-              ] [
-                i: 0 dynamic;
-                [
-                  i processorResult.errorInfo.position.dataSize < [
-                    nodePosition: i processorResult.errorInfo.position.at;
+              processorResult.globalErrorInfo [
+                pair:;
+                current: pair.value;
+                pair.index 0 > [LF print] when 
+                current.position.getSize 0 = [
+                  ("error, "  current.message) printList LF print
+                ] [
+                  current.position [
+                    pair:;
+                    i: pair.index;
+                    nodePosition: pair.value;
                     (nodePosition.filename options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
 
                     i 0 = [
-                      ("error, [" nodePosition.token "], " processorResult.errorInfo.message) printList LF print
+                      ("error, [" nodePosition.token "], " current.message LF) printList
                     ] [
-                      ("[" nodePosition.token "], called from here") printList LF print
+                      ("[" nodePosition.token "], called from here" LF) printList
                     ] if
+                  ] each
+                ] if
 
-                    i 1 + @i set TRUE
-                  ] &&
-                ] loop
-              ] if
-
-              FALSE @success set
+                FALSE @success set
+              ] each
             ] if
           ] when
         ] if

--- a/main.mpl
+++ b/main.mpl
@@ -239,7 +239,7 @@ createDefinition: [
               processorResult.globalErrorInfo [
                 pair:;
                 current: pair.value;
-                pair.index 0 > [LF print] when 
+                pair.index 0 > [LF print] when
                 current.position.getSize 0 = [
                   ("error, "  current.message) printList LF print
                 ] [

--- a/main.mpl
+++ b/main.mpl
@@ -24,7 +24,7 @@ printInfo: [
   "  -verbose_ir         Print information about current token in IR" print LF print
   "  -version            Print compiler version while compiling" print LF print
   FALSE @success set
-] func;
+];
 
 addToProcess: [
   fileText:;
@@ -44,7 +44,7 @@ addToProcess: [
       parserResult.errorInfo.message) assembleString print LF print
     FALSE @success set
   ] if
-] func;
+];
 
 createDefinition: [
   splittedOption:;
@@ -70,7 +70,7 @@ createDefinition: [
     value: eqIndex 1 + splittedOption.chars.getSize splittedOption.chars makeSubRange assembleString;
     (name makeStringView ": [" value makeStringView " static];" LF) assembleString @definitions.cat
   ] if
-] func;
+];
 
 {argc: 0; argv: 0nx;} 0 {convention: cdecl;} [
   ("Start mplc compiler") addLog

--- a/main.mpl
+++ b/main.mpl
@@ -68,7 +68,7 @@ createDefinition: [
   ] [
     name: 0 eqIndex splittedOption.chars makeSubRange assembleString;
     value: eqIndex 1 + splittedOption.chars.getSize splittedOption.chars makeSubRange assembleString;
-    (name makeStringView ": { CALL: [" value makeStringView " static]; };" LF) assembleString @definitions.cat
+    (name makeStringView ": [" value makeStringView " static];" LF) assembleString @definitions.cat
   ] if
 ] func;
 

--- a/parser.mpl
+++ b/parser.mpl
@@ -540,27 +540,27 @@ parseDecNumber: [
 
   token: tokenBegin tokenEnd splittedString.chars makeSubRange assembleString;
 
-  afterT.dataSize 2 > [ "error in number constant" lexicalError ] when
+  afterT.getSize 2 > [ "error in number constant" lexicalError ] when
 
   typeName: 0 dynamic;
-  afterT.dataSize [typeName 100 * i afterT.at + 1 + @typeName set] times
+  afterT.getSize [typeName 100 * i afterT.at + 1 + @typeName set] times
 
 
   typeClass 2 = [
     type: 0.0r64 dynamic;
     ten: 10.0r64 dynamic;
     result: 0.0r64 dynamic;
-    beforeDot.dataSize [result 10.0r64 * i beforeDot.at type cast + @result set] times
+    beforeDot.getSize [result 10.0r64 * i beforeDot.at type cast + @result set] times
     tenRcp: 0.1r64 dynamic;
     fracPartFactor: tenRcp copy;
-    afterDot.dataSize [
+    afterDot.getSize [
       digit: i afterDot.at type cast;
       digit  fracPartFactor * result + @result set
       fracPartFactor tenRcp * @fracPartFactor set
     ] times
 
     decOrder: 0.0r64 dynamic;
-    afterE.dataSize [decOrder 10.0r64 * i afterE.at type cast + @decOrder set] times
+    afterE.getSize [decOrder 10.0r64 * i afterE.at type cast + @decOrder set] times
     hasEMinus [decOrder neg @decOrder set] when
     hasMinus [result neg @result set] when
     result 10.0r64 decOrder ^ * @result set
@@ -580,7 +580,7 @@ parseDecNumber: [
       type: 0n64 dynamic;
       ten: 10n64 dynamic;
       result: 0n64 dynamic;
-      beforeDot.dataSize [result 10n64 * i beforeDot.at 0i64 cast type cast + @result set] times
+      beforeDot.getSize [result 10n64 * i beforeDot.at 0i64 cast type cast + @result set] times
       typeName 705 = [
         result token makeNumbern64Node @mainResult.@memory.pushBack
       ] [
@@ -606,7 +606,7 @@ parseDecNumber: [
       type: 0i64 dynamic;
       ten: 10i64 dynamic;
       result: 0i64 dynamic;
-      beforeDot.dataSize [result 10i64 * i beforeDot.at type cast + @result set] times
+      beforeDot.getSize [result 10i64 * i beforeDot.at type cast + @result set] times
       hasMinus [result neg @result set] when
       typeName 705 = [
         result token makeNumberi64Node @mainResult.@memory.pushBack
@@ -690,17 +690,18 @@ parseHexNumber: [
   ] loop
 
   token: tokenBegin tokenEnd splittedString.chars makeSubRange assembleString;
-  afterT.dataSize 2 > [ "error in number constant" lexicalError ] when
+  afterT.getSize 2 > [ "error in number constant" lexicalError ] when
 
   typeName: 0 dynamic;
-  afterT.dataSize [typeName 100 * i afterT.at + 1 + @typeName set] times
+  afterT.getSize [typeName 100 * i afterT.at + 1 + @typeName set] times
   hasMinus ["negative hex constants not allowed" lexicalError] when
 
   typeClass 1 = [
     type: 0n64;
     ten: 10n64;
     result: 0n64;
-    beforeT.dataSize [result 16n64 * i beforeT.at 0i64 cast type cast + @result set] times
+    beforeT.getSize 0 = ["empty hex constant" lexicalError] when
+    beforeT.getSize [result 16n64 * i beforeT.at 0i64 cast type cast + @result set] times
     typeName 705 = [
       result token makeNumbern64Node @mainResult.@memory.pushBack
     ] [
@@ -808,7 +809,7 @@ parseName: [
         FALSE
       ] [
         currentCode ascii.dot = [
-          nameSymbols.dataSize 0 > [
+          nameSymbols.getSize 0 > [
             FALSE
           ] [
             checkFirst
@@ -828,7 +829,7 @@ parseName: [
               TRUE @write set
               iterate TRUE
             ] [
-              currentCode ascii.comma = nameSymbols.dataSize 0 > and [
+              currentCode ascii.comma = nameSymbols.getSize 0 > and [
                 FALSE
               ] [
                 currentCode pc.endNames inArray [
@@ -838,7 +839,7 @@ parseName: [
                   ] when
                   FALSE
                 ] [
-                  nameSymbols.dataSize 1 > [0 nameSymbols.at "," =] && [
+                  nameSymbols.getSize 1 > [0 nameSymbols.at "," =] && [
                     "identifier cannot start from comma" lexicalError
                   ] when
                   currentSymbol @nameSymbols.pushBack
@@ -859,7 +860,7 @@ parseName: [
   mainResult.success [
     read write and ["wrong identifier" lexicalError] when
 
-    nameSymbols.dataSize 0 = [
+    nameSymbols.getSize 0 = [
       member [
         read write or [undo "wrong identifier" lexicalError] when
         "." makeNameNode @mainResult.@memory.pushBack
@@ -959,7 +960,7 @@ addNestedNode: [
 
 addToLastUnfinished: [
   @mainResult.@memory.pushBack
-  mainResult.memory.dataSize 1 - @unfinishedNodes.last.pushBack
+  mainResult.memory.getSize 1 - @unfinishedNodes.last.pushBack
 ];
 
 parseNode: [
@@ -1003,7 +1004,7 @@ parseNode: [
                     addToLastUnfinished
                   ] [
                     currentCode ascii.null = [
-                      unfinishedNodes.dataSize 1 = not [
+                      unfinishedNodes.getSize 1 = not [
                         "unexpected end of the file!" makeStringView lexicalError
                       ] when
                       0 @unfinishedNodes.at @mainResult.@nodes set
@@ -1055,12 +1056,12 @@ parseNode: [
     ] [
       lastPosition: currentPosition copy;
       parseIdentifier [
-        mainResult.memory.dataSize 1 -   # if made label, dont do it
+        mainResult.memory.getSize 1 -   # if made label, dont do it
         @unfinishedNodes.last.pushBack
       ] when
     ] if
 
-    unfinishedNodes.dataSize 0 > [mainResult.success copy] &&
+    unfinishedNodes.getSize 0 > [mainResult.success copy] &&
   ] loop
 ];
 

--- a/parser.mpl
+++ b/parser.mpl
@@ -434,7 +434,7 @@ tryParseNumberAfterSign: [
   ] if
 ];
 
-dCheck: [currentCode pc.digits inArray not ["wrong number constant" lexicalError] when ];
+dCheck: [currentCode pc.digits inArray not ["wrong number constant" lexicalError] when];
 
 xCheck: [
   currentCode pc.digits inArray not [

--- a/parser.mpl
+++ b/parser.mpl
@@ -726,7 +726,8 @@ parseHexNumber: [
     type: 0i64 dynamic;
     ten: 10i64 dynamic;
     result: 0i64 dynamic;
-    beforeT.dataSize [result 16i64 * i beforeT.at type cast + @result set] times
+    beforeT.getSize 0 = ["empty hex constant" lexicalError] when
+    beforeT.getSize [result 16i64 * i beforeT.at type cast + @result set] times
     typeName 705 = [
       result token makeNumberi64Node @mainResult.@memory.pushBack
     ] [

--- a/parser.mpl
+++ b/parser.mpl
@@ -534,7 +534,7 @@ parseDecNumber: [
     ] if
 
     p:;
-    p [ currentPosition.offset @tokenEnd set ] when
+    p [currentPosition.offset @tokenEnd set] when
     p mainResult.success and
   ] loop
 

--- a/parser.mpl
+++ b/parser.mpl
@@ -9,7 +9,7 @@ fillPositionInfo: [
   lastPosition.line @astNode.@line set
   lastPosition.column @astNode.@column set
   currentFileNumber @astNode.@fileNumber set
-] func;
+];
 
 makeLabelNode: [
   children:;
@@ -22,7 +22,7 @@ makeLabelNode: [
   children @branch.@children set
   name @branch.@name set
   @result
-] func;
+];
 
 makeCodeNode: [
   children:;
@@ -33,7 +33,7 @@ makeCodeNode: [
   branch: AstNodeType.Code @result.@data.get;
   children @branch set
   @result
-] func;
+];
 
 makeObjectNode: [
   children:;
@@ -44,7 +44,7 @@ makeObjectNode: [
   branch: AstNodeType.Object @result.@data.get;
   children @branch set
   @result
-] func;
+];
 
 makeListNode: [
   children:;
@@ -55,7 +55,7 @@ makeListNode: [
   branch: AstNodeType.List @result.@data.get;
   children @branch set
   @result
-] func;
+];
 
 makeNameNode: [
   name:;
@@ -66,7 +66,7 @@ makeNameNode: [
   branch: AstNodeType.Name @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeNameReadNode: [
   name:;
@@ -77,7 +77,7 @@ makeNameReadNode: [
   branch: AstNodeType.NameRead @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeNameWriteNode: [
   name:;
@@ -88,7 +88,7 @@ makeNameWriteNode: [
   branch: AstNodeType.NameWrite @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeNameMemberNode: [
   name:;
@@ -99,7 +99,7 @@ makeNameMemberNode: [
   branch: AstNodeType.NameMember @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeNameReadMemberNode: [
   name:;
@@ -110,7 +110,7 @@ makeNameReadMemberNode: [
   branch: AstNodeType.NameReadMember @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeNameWriteMemberNode: [
   name:;
@@ -121,7 +121,7 @@ makeNameWriteMemberNode: [
   branch: AstNodeType.NameWriteMember @result.@data.get;
   name toString @branch.@name set
   @result
-] func;
+];
 
 makeStringNode: [
   value:;
@@ -132,7 +132,7 @@ makeStringNode: [
   branch: AstNodeType.String @result.@data.get;
   value @branch set
   @result
-] func;
+];
 
 makeNumberi8Node: [
   token:;
@@ -144,7 +144,7 @@ makeNumberi8Node: [
   branch: AstNodeType.Numberi8 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumberi16Node: [
   token:;
@@ -156,7 +156,7 @@ makeNumberi16Node: [
   branch: AstNodeType.Numberi16 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumberi32Node: [
   token:;
@@ -168,7 +168,7 @@ makeNumberi32Node: [
   branch: AstNodeType.Numberi32 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumberi64Node: [
   token:;
@@ -180,7 +180,7 @@ makeNumberi64Node: [
   branch: AstNodeType.Numberi64 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumberixNode: [
   token:;
@@ -192,7 +192,7 @@ makeNumberixNode: [
   branch: AstNodeType.Numberix @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumbern8Node: [
   token:;
@@ -204,7 +204,7 @@ makeNumbern8Node: [
   branch: AstNodeType.Numbern8 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumbern16Node: [
   token:;
@@ -216,7 +216,7 @@ makeNumbern16Node: [
   branch: AstNodeType.Numbern16 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumbern32Node: [
   token:;
@@ -228,7 +228,7 @@ makeNumbern32Node: [
   branch: AstNodeType.Numbern32 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumbern64Node: [
   token:;
@@ -240,7 +240,7 @@ makeNumbern64Node: [
   branch: AstNodeType.Numbern64 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeNumbernxNode: [
   token:;
@@ -252,7 +252,7 @@ makeNumbernxNode: [
   branch: AstNodeType.Numbernx @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeReal32Node: [
   token:;
@@ -264,7 +264,7 @@ makeReal32Node: [
   branch: AstNodeType.Real32 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeReal64Node: [
   token:;
@@ -276,41 +276,41 @@ makeReal64Node: [
   branch: AstNodeType.Real64 @result.@data.get;
   number @branch set
   @result
-] func;
+];
 
 makeParserConstants: [{
-  eof:        [  0n32] func;
+  eof:        [  0n32];
 
-  cr:         [ 13n32] func;
-  lf:         [ 10n32] func;
-  space:      [ 32n32] func;
-  exclamation:[ 33n32] func;
-  quote:      [ 34n32] func;
-  grid:       [ 35n32] func;
-  openRBr:    [ 40n32] func;
-  closeRBr:   [ 41n32] func;
-  openSBr:    [ 91n32] func;
-  closeSBr:   [ 93n32] func;
-  openFBr:    [123n32] func;
-  closeFBr:   [125n32] func;
-  plus:       [ 43n32] func;
-  comma:      [ 44n32] func;
-  minus:      [ 45n32] func;
-  dot:        [ 46n32] func;
-  zero:       [ 48n32] func;
-  colon:      [ 58n32] func;
-  semicolon:  [ 59n32] func;
-  dog:        [ 64n32] func;
-  backSlash:  [ 92n32] func;
+  cr:         [ 13n32];
+  lf:         [ 10n32];
+  space:      [ 32n32];
+  exclamation:[ 33n32];
+  quote:      [ 34n32];
+  grid:       [ 35n32];
+  openRBr:    [ 40n32];
+  closeRBr:   [ 41n32];
+  openSBr:    [ 91n32];
+  closeSBr:   [ 93n32];
+  openFBr:    [123n32];
+  closeFBr:   [125n32];
+  plus:       [ 43n32];
+  comma:      [ 44n32];
+  minus:      [ 45n32];
+  dot:        [ 46n32];
+  zero:       [ 48n32];
+  colon:      [ 58n32];
+  semicolon:  [ 59n32];
+  dog:        [ 64n32];
+  backSlash:  [ 92n32];
   # it is for numbers
-  aCode:      [ 97n32] func;
-  aCodeBig:   [ 65n32] func;
-  eCode:      [101n32] func;
-  eCodeBig:   [ 69n32] func;
-  iCode:      [105n32] func;
-  nCode:      [110n32] func;
-  rCode:      [114n32] func;
-  xCode:      [120n32] func;
+  aCode:      [ 97n32];
+  aCodeBig:   [ 65n32];
+  eCode:      [101n32];
+  eCodeBig:   [ 69n32];
+  iCode:      [105n32];
+  nCode:      [110n32];
+  rCode:      [114n32];
+  xCode:      [120n32];
 
   makeLookupTable: [
     av:;
@@ -323,7 +323,7 @@ makeParserConstants: [{
     ] each
 
     result
-  ] func;
+  ];
 
   joinLookupTables: [
     right:;
@@ -338,7 +338,7 @@ makeParserConstants: [{
     ] each
 
     result
-  ] func;
+  ];
 
   starters: (openRBr openSBr openFBr) makeLookupTable;
   terminators: (eof closeRBr closeSBr closeFBr semicolon) makeLookupTable;
@@ -364,13 +364,13 @@ makeParserConstants: [{
     6n32  [i 10 + 0n32 cast aCodeBig 0 cast i + @result.at set] times
     result
   ] call;
-}] func;
+}];
 
 inArray: [
   where:;
   copy code:;
   code 256n32 < [code 0 cast where.at copy] &&
-] func;
+];
 
 undo: [
   mainResult.success [
@@ -383,7 +383,7 @@ undo: [
       pc.eof @currentCode set
     ] if
   ] when
-] func;
+];
 
 iterate: [
   mainResult.success [
@@ -405,13 +405,13 @@ iterate: [
       pc.eof @currentCode set
     ] if
   ] when
-] func;
+];
 
 lexicalError: [
   toString @mainResult.@errorInfo.@message set
   currentPosition @mainResult.@errorInfo.@position set
   FALSE @mainResult.@success set
-] func;
+];
 
 parseStringConstant: [
   nameSymbols: StringView Array;
@@ -453,7 +453,7 @@ parseStringConstant: [
 
   nameSymbols assembleString makeStringNode @mainResult.@memory.pushBack
   TRUE
-] func;
+];
 
 tryParseNumberAfterSign: [
   currentCode pc.digits inArray [
@@ -461,9 +461,9 @@ tryParseNumberAfterSign: [
   ] [
     undo parseName
   ] if
-] func;
+];
 
-dCheck: [currentCode pc.digits inArray not ["wrong number constant" lexicalError] when ] func;
+dCheck: [currentCode pc.digits inArray not ["wrong number constant" lexicalError] when ];
 xCheck: [
   currentCode pc.digits inArray not [
     currentCode pc.xCode = [
@@ -473,12 +473,12 @@ xCheck: [
       "wrong number constant" lexicalError
     ] if
   ] when
-] func;
+];
 
 parseDecNumber: [
   copy hasMinus:;
 
-  IntArray: [Int32 Array] func;
+  IntArray: [Int32 Array];
   beforeDot: IntArray;
   afterDot: IntArray;
   afterE: IntArray;
@@ -661,11 +661,11 @@ parseDecNumber: [
   ] if
 
   mainResult.success copy
-] func;
+];
 
 parseHexNumber: [
   copy hasMinus:;
-  IntArray: [Int32 Array] func;
+  IntArray: [Int32 Array];
   beforeT: IntArray;
   afterT: IntArray;
   currentArray: @beforeT;
@@ -779,7 +779,7 @@ parseHexNumber: [
   ] if
 
   mainResult.success copy
-] func;
+];
 
 parseNumber: [
   hasMinus: FALSE dynamic;
@@ -805,7 +805,7 @@ parseNumber: [
   ] [
     hasMinus parseDecNumber
   ] if
-] func;
+];
 
 makeLabel: [
   name:;
@@ -813,7 +813,7 @@ makeLabel: [
   pc.semicolon @unfinishedTerminators.pushBack
   name toString @unfinishedLabelNames.pushBack
   IndexArray @unfinishedNodes.pushBack
-] func;
+];
 
 parseName: [
   member: FALSE dynamic;
@@ -821,7 +821,7 @@ parseName: [
   write: FALSE dynamic;
   label: FALSE dynamic;
   checkOffset: currentPosition.offset copy;
-  checkFirst: [currentPosition.offset checkOffset > ["invalid identifier" lexicalError] when] func;
+  checkFirst: [currentPosition.offset checkOffset > ["invalid identifier" lexicalError] when];
   nameSymbols: StringView Array;
   first: TRUE dynamic;
 
@@ -936,7 +936,7 @@ parseName: [
   ] [
     FALSE
   ] if
-] func;
+];
 
 parseIdentifier: [
   compileOnce
@@ -954,14 +954,14 @@ parseIdentifier: [
       ] if
     ] if
   ] if
-] func;
+];
 
 parseComment: [
   [
     iterate
     currentCode pc.eof = currentCode pc.lf = or not
   ] loop
-] func;
+];
 
 addNestedNode: [
   currentPosition @unfinishedPositions.pushBack
@@ -982,12 +982,12 @@ addNestedNode: [
   ] if
 
   iterate
-] func;
+];
 
 addToLastUnfinished: [
   @mainResult.@memory.pushBack
   mainResult.memory.dataSize 1 - @unfinishedNodes.last.pushBack
-] func;
+];
 
 parseNode: [
   [
@@ -1089,7 +1089,7 @@ parseNode: [
 
     unfinishedNodes.dataSize 0 > [mainResult.success copy] &&
   ] loop
-] func;
+];
 
 {
   currentFileNumber: Int32;

--- a/parser.mpl
+++ b/parser.mpl
@@ -545,7 +545,6 @@ parseDecNumber: [
   typeName: 0 dynamic;
   afterT.getSize [typeName 100 * i afterT.at + 1 + @typeName set] times
 
-
   typeClass 2 = [
     type: 0.0r64 dynamic;
     ten: 10.0r64 dynamic;

--- a/parser.mpl
+++ b/parser.mpl
@@ -1,12 +1,14 @@
 "parser" module
-"control" useModule
+"control" includeModule
+"String" includeModule
+"astNodeType" includeModule
 
 fillPositionInfo: [
   astNode:;
   lastPosition.offset @astNode.@offset set
   lastPosition.line @astNode.@line set
   lastPosition.column @astNode.@column set
-  currentFileName @astNode.@filename set
+  currentFileNumber @astNode.@fileNumber set
 ] func;
 
 makeLabelNode: [
@@ -1089,11 +1091,14 @@ parseNode: [
   ] loop
 ] func;
 
-parseString: [
-  compileOnce
-  copy currentFileName:;
-  splittedString: makeStringView.split;
-  mainResult: ParserResult;
+{
+  currentFileNumber: Int32;
+  text: StringView Cref;
+  mainResult: ParserResult Ref;
+} () {convention: cdecl;} [
+  copy currentFileNumber:;
+  splittedString: .split;
+  mainResult:;
   splittedString.success [
     currentPosition: PositionInfo;
     prevPosition: PositionInfo;
@@ -1120,6 +1125,4 @@ parseString: [
     0 @mainResult.@errorInfo.@position.@line set
     splittedString.errorOffset 0 cast @mainResult.@errorInfo.@position.@column set
   ] if
-
-  @mainResult
-] func;
+] "parseString" exportFunction

--- a/pathUtils.mpl
+++ b/pathUtils.mpl
@@ -20,7 +20,7 @@ extractClearPath: [
       String
     ] if
   ] call
-] func;
+];
 
 simplifyPath: [
   splittedPath: makeStringView.split;
@@ -35,8 +35,8 @@ simplifyPath: [
         fragments: String Array;
         String @fragments.pushBack
 
-        isCurrent: ["." =] func;
-        isBack: [".." =] func;
+        isCurrent: ["." =];
+        isBack: [".." =];
 
         splittedPath.chars [
           pair:;
@@ -79,4 +79,4 @@ simplifyPath: [
       String String
     ] if
   ] call
-] func;
+];

--- a/printAST.mpl
+++ b/printAST.mpl
@@ -6,123 +6,123 @@ printLabelNode: [
   ("; Label:" data.name "; id:" data.nameInfo) printList
   data.children cref @unfinishedNodes.pushBack
   0n32 @unfinishedIndexes.pushBack
-] func;
+];
 
 printCodeNode: [
   cref data:;
   ("; Code:") printList
   data deref cref @unfinishedNodes.pushBack
   0n32 @unfinishedIndexes.pushBack
-] func;
+];
 
 printObjectNode: [
   cref data:;
   ("; Object:") printList
   data deref cref @unfinishedNodes.pushBack
   0n32 @unfinishedIndexes.pushBack
-] func;
+];
 
 printListNode: [
   cref data:;
   ("; List:") printList
   data deref cref @unfinishedNodes.pushBack
   0n32 @unfinishedIndexes.pushBack
-] func;
+];
 
 printNameNode: [
   cref data:;
   ("; Name:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printNameReadNode: [
   cref data:;
   ("; NameRead:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printNameWriteNode: [
   cref data:;
   ("; NameWrite:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printNameMemberNode: [
   cref data:;
   ("; NameMember:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printNameReadMemberNode: [
   cref data:;
   ("; NameReadMember:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printNameWriteMemberNode: [
   cref data:;
   ("; NameWriteMember:" data.name "; id:" data.nameInfo) printList
-] func;
+];
 
 printStringNode: [
   cref data:;
   ("; String:" data deref) printList
-] func;
+];
 
 printInt8Node: [
   cref data:;
   ("; Int8:" data deref) printList
-] func;
+];
 
 printInt16Node: [
   cref data:;
   ("; Int16:" data deref) printList
-] func;
+];
 
 printInt32Node: [
   cref data:;
   ("; Int32:" data deref) printList
-] func;
+];
 
 printInt64Node: [
   cref data:;
   ("; Int64:" data deref) printList
-] func;
+];
 
 printIntXNode: [
   cref data:;
   ("; IntX:" data deref) printList
-] func;
+];
 
 printNat8Node: [
   cref data:;
   ("; Nat8:" data deref) printList
-] func;
+];
 
 printNat16Node: [
   cref data:;
   ("; Nat16:" data deref) printList
-] func;
+];
 
 printNat32Node: [
   cref data:;
   ("; Nat32:" data deref) printList
-] func;
+];
 
 printNat64Node: [
   cref data:;
   ("; Nat64:" data deref) printList
-] func;
+];
 
 printNatXNode: [
   cref data:;
   ("; NatX:" data deref) printList
-] func;
+];
 
 printReal32Node: [
   cref data:;
   ("; Real32:" data deref) printList
-] func;
+];
 
 printReal64Node: [
   cref data:;
   ("; Real64:" data deref) printList
-] func;
+];
 
 printCurrentNode: [
   cref node:;
@@ -157,7 +157,7 @@ printCurrentNode: [
 
   ("; token:" node.token) printList
   LF print
-] func;
+];
 
 printAST: [
   ref parserResult:;
@@ -183,4 +183,4 @@ printAST: [
       unfinishedNodes.dataSize 0n32 >
     ] if
   ] loop
-] func;
+];

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -201,7 +201,6 @@ compareOnePair: [
           cacheEntryVar: currentFromCache getVar;
           stackEntryVar: currentFromStack getVar;
           cacheEntryVar.data.getTag VarRef = [currentFromCache staticnessOfVar Virtual <] && [currentFromCache staticnessOfVar Weak >] && [
-
             currentFromStack getPointeeForMatching @unfinishedStack.pushBack
             currentFromCache getPointeeForMatching @unfinishedCache.pushBack
             i -1 "deref" makeStringView makeWayInfo @unfinishedWay.pushBack
@@ -1721,7 +1720,6 @@ processIf: [
               processor.options.verboseIR ["end if" makeStringView createComent] when
             ] when
           ] when
-
         ] when
       ] if
     ] when

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -264,7 +264,7 @@ getOverload: [
   maxOverloadCountCur: cap.nameInfo getOverloadCount;
   maxOverloadCountNes: cap.cntNameOverload copy;
   overload maxOverloadCountCur + maxOverloadCountNes < [
-    ("While matching cant call overload for name: " cap.nameInfo processor.nameInfos.at.name) assembleString compilerError
+    ("while matching cant call overload for name: " cap.nameInfo processor.nameInfos.at.name) assembleString compilerError
     0
   ] [
     overload maxOverloadCountCur + maxOverloadCountNes -

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -93,10 +93,7 @@ variablesAreEqual: [
 
 variableIsUnused: [
   refToVar:;
-  #refToVar variableIsDeleted [
   refToVar.hostId currentMatchingNodeIndex = not [refToVar noMatterToCopy not] &&
-  #] ||
-  #] ||
 ];
 
 compareOnePair: [
@@ -560,9 +557,6 @@ fixRef: [
   pointeeVar: pointee getVar;
   pointeeIsLocal: pointeeVar.capturedHead.hostId currentChangesNodeIndex =;
 
-  #("fix " refToVar.hostId ":" refToVar.varId "; to " pointee.hostId ":" pointee.varId) addLog
-  #pointee: refToVar getPointeeNoDerefIR;
-
   fixed: pointee copy;
   pointeeIsLocal not [ # has shadow - captured from top
     fr: pointeeVar.shadowBegin appliedVars.nestedToCur.find;
@@ -579,22 +573,10 @@ fixRef: [
     var.staticness Static = [pointeeVar.storageStaticness Static =] && ["returning pointer to local variable" compilerError] when
     pointee copyVarFromChild @fixed set
     TRUE dynamic @makeDynamic set
-
-    #todo: make it good
-    #var.shadowBegin.hostId processor.nodes.dataSize < [
-    #  refShadowBegin: var.shadowBegin;
-    #  shadowBeginPointee: VarRef refShadowBegin getVar.@data.get;
-    #  shadowBeginPointee.hostId processor.nodes.dataSize < not [
-    #    pointee copyVarFromChild @shadowBeginPointee set
-    #  ] when
-    #  shadowBeginPointee pointee getVar.@shadowBegin set
-    #  pointee shadowBeginPointee getVar.@shadowEnd set
-    #] when
   ] if
 
   fixed.hostId @pointee.@hostId set
   fixed.varId  @pointee.@varId  set
-  #("/fix " refToVar.hostId ":" refToVar.varId "; to " pointee.hostId ":" pointee.varId) addLog
 
   wasVirtual [refToVar Virtual makeStaticness @refToVar set] [
     makeDynamic [
@@ -607,10 +589,6 @@ fixRef: [
 applyOnePair: [
   cacheEntry:;
   stackEntry:;
-
-  #("aop, type=" cacheEntry getMplType
-  #  "; ce=" cacheEntry.hostId ":" cacheEntry.varId ":" cacheEntry isGlobal
-  #  "; se=" stackEntry.hostId ":" stackEntry.varId ":" stackEntry isGlobal) addLog
 
   [
     cacheEntry stackEntry variablesAreSame [TRUE] [
@@ -754,7 +732,6 @@ fixOutputRefsRec: [
         stackPointee: VarRef @stackEntryVar.@data.get;
         stackPointee.hostId currentChangesNodeIndex = [
           fixed: currentFromStack fixRef getPointeeNoDerefIR;
-          #("fix ref output, fixed=" fixed.hostId ":" fixed.varId " g=" fixed isGlobal) addLog
           fixed @unfinishedStack.pushBack
         ] when
       ] [
@@ -925,9 +902,6 @@ applyNodeChanges: [
       overload: currentCapture getOverload;
 
       stackEntry: currentCapture.nameInfo currentCapture overload getNameForMatchingWithOverload captureName.refToVar;
-      #("capture; name=" currentCapture.nameInfo processor.nameInfos.at.name "; ctype=" cacheEntry getMplType "; stype=" stackEntry getMplType) addLog
-      #("capture; se=" stackEntry.hostId ":" stackEntry.varId ":" stackEntry staticnessOfVar) addLog
-      #("capture; ce=" cacheEntry.hostId ":" cacheEntry.varId ":" cacheEntry staticnessOfVar) addLog
       stackEntry cacheEntry applyEntriesRec
       i 1 + @i set compilable
     ] &&
@@ -945,18 +919,6 @@ applyNodeChanges: [
       i 1 + @i set compilable
     ] &&
   ] loop
-
-  #("curToNested") addLog
-  #appliedVars.curToNested [
-  #  pair:;
-  #  (pair.key.hostId ":" pair.key.varId " s " pair.key staticnessOfVar " <-> " pair.value.hostId ":" pair.value.varId " s " pair.value staticnessOfVar " t" pair.key getMplType) addLog
-  #] each
-
-  #("nestedToCur") addLog
-  #appliedVars.nestedToCur [
-  #  pair:;
-  #  (pair.key.hostId ":" pair.key.varId " s " pair.key staticnessOfVar " <-> " pair.value.hostId ":" pair.value.varId " s " pair.value staticnessOfVar " t" pair.key getMplType) addLog
-  #] each
 
   i: 0 dynamic;
   [
@@ -1272,30 +1234,7 @@ processCallByNode: [
     CFunctionSignature
     astNodeToCodeNode @newNodeIndex set
 
-    #newNodeIndex @processor.@nodes.at.get.irName @forcedNameString set
   ] [
-    #newNode: newNodeIndex @processor.@nodes.at.get;
-    #newNode.state NodeStateCompiled = [
-    #  "@alias_" toString @forcedNameString set
-    #  splitted: name.split;
-    #  splitted.success [
-    #    splitted.chars [
-    #      symbol: .value;
-    #      codePoint: symbol stringMemory Nat8 addressToReference;
-    #      codePoint 48n8 < not [codePoint 57n8 > not] &&         #0..9
-    #      [codePoint 65n8 < not [codePoint 90n8 > not] &&] ||    #A..Z
-    #      [codePoint 97n8 < not [codePoint 122n8 > not] &&] || [ #a..z
-    #        symbol @forcedNameString.cat
-    #      ] when
-    #    ] each
-    #  ] when
-
-    #  ("." processor.funcAliasCount) @forcedNameString.catMany
-    #  processor.funcAliasCount 1 + @processor.@funcAliasCount set
-    #  forcedNameString newNode.irName newNodeIndex getFuncIrType createFuncAliasIR @newNode.@aliases.pushBack
-    #] [
-    #  newNodeIndex @processor.@nodes.at.get.irName @forcedNameString set
-    #] if
   ] if
 
   compilable [
@@ -1764,7 +1703,6 @@ processLoop: [
       ] [
         newNode.state NodeStateHasOutput = [NodeStateHasOutput @currentNode.@state set] when
         appliedVars: newNodeIndex applyNodeChanges;
-        #newNode usePreCaptures
 
         appliedVars.fixedOutputs.getSize 0 = ["loop body must return Cond" makeStringView compilerError] when
         compilable [
@@ -1855,9 +1793,6 @@ processDynamicLoop: [
         appliedVars.curToNested [
           pair:;
 
-          #("loop checking; key=" pair.key.hostId ":" pair.key.varId " g=" pair.key isGlobal ":" pair.key getVar.globalId " s=" pair.key staticnessOfVar
-          #  "; value=" pair.value.hostId ":" pair.value.varId " g=" pair.value isGlobal ":" pair.value getVar.globalId " s=" pair.value staticnessOfVar
-          #  "; type=" pair.key getMplType) addLog
           pair.key pair.value checkToRecompile [
             pair.value staticnessOfVar Dirty = [
               pair.key makeVarDirty
@@ -2055,16 +1990,10 @@ nSwap: [
       newNode.captureNames [
         currentCaptureName: .value;
         currentCaptureName.startPoint indexOfNode = not [
-          #("use cap from module " currentCaptureName.startPoint " while get name " currentCaptureName.nameInfo processor.nameInfos.at.name " type " refToVar getMplType) addLog
           fr: currentCaptureName.startPoint @currentNode.@usedModulesTable.find;
           fr.success [TRUE @fr.@value.@used set] when
         ] when
       ] each
-
-      #newNode.matchingInfo.captures [
-      #  capture: .value;
-      #  ("capture; name=" capture.nameInfo processor.nameInfos.at.name "; ctype=" capture.refToVar getMplType) addLog
-      #] each
 
       signature.outputs [
         pair:;
@@ -2122,8 +2051,6 @@ nSwap: [
     FALSE @r.@mutable set
     r push
   ] each
-
-  #signature.inputs.getSize nSwap
 
   [
     curPosition: currentNode.position;
@@ -2208,35 +2135,6 @@ callImportWith: [
           ]
         ) sequence
       ] when
-    ] [
-      #i: 0 dynamic;
-      #[
-      #  i declarationNode.matchingInfo.captures.dataSize < [
-      #    currentCapture: i declarationNode.matchingInfo.captures.at;
-      #    currentCapture.refToVar isVirtual not [
-      #      (
-      #        [compilable]
-      #        [
-      #          overload: currentCapture getOverload;
-      #          stackEntry: currentCapture.nameInfo currentCapture.refToVar overload getNameForMatchingWithOverload.refToVar;
-      #          stackEntry.hostId 0 < [
-      #            ("cant call import, capture " currentCapture.nameInfo processor.nameInfos.at.name " not found") assembleString compilerError
-      #          ] when
-
-      #        ] [
-      #          nodeEntry: currentCapture.refToVar;
-      #          stackEntry nodeEntry variablesAreSame not [
-      #            ("cant call import, capture " currentCapture.nameInfo processor.nameInfos.at.name " types are incorrect, expected " nodeEntry getMplType ";" LF "but found " stackEntry getMplType) assembleString compilerError
-      #          ] when
-      #        ] [
-      #          stackEntry makeVarTreeDynamic
-      #          #dont need pushBack to captures, it will find it itself
-      #        ]
-      #      ) sequence
-      #    ] when
-      #    i 1 + @i set compilable
-      #  ] &&
-      #] loop
     ] [
       i: 0 dynamic;
       [

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -2007,6 +2007,10 @@ nSwap: [
   positionInfo: astNode makeCompilerPosition;
   compileOnce
 
+
+  signature.variadic [
+    "export function cannot be variadic" compilerError
+  ] when
   ("process export: " makeStringView name makeStringView) addLog
 
   # we dont know count of used in export entites
@@ -2020,9 +2024,6 @@ nSwap: [
     r push
   ] each
 
-  signature.variadic [
-    "export function cannot be variadic" compilerError
-  ] when
 
   oldSuccess: compilable;
   oldRecursiveNodesStackSize: processor.recursiveNodesStack.getSize;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -13,7 +13,7 @@ clearProcessorResult: [
   cachedGlobalErrorInfoSize 0 < not [
     cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
   ] when
-] func;
+];
 
 variablesHaveSameGlobality: [
   cacheEntry:;
@@ -27,7 +27,7 @@ variablesHaveSameGlobality: [
   ] [
     stackEntry isGlobal not
   ] if
-] func;
+];
 
 variablesAreEqualWith: [
   copy checkRefs:;
@@ -81,15 +81,15 @@ variablesAreEqualWith: [
       ] || # both dynamic
     ] if
   ] &&
-] func;
+];
 
 variablesAreEqualForMatching: [
   Weak FALSE dynamic variablesAreEqualWith
-] func;
+];
 
 variablesAreEqual: [
   Dynamic TRUE dynamic variablesAreEqualWith
-] func;
+];
 
 variableIsUnused: [
   refToVar:;
@@ -97,7 +97,7 @@ variableIsUnused: [
   refToVar.hostId currentMatchingNodeIndex = not [refToVar noMatterToCopy not] &&
   #] ||
   #] ||
-] func;
+];
 
 compareOnePair: [
   copy first:;
@@ -134,7 +134,7 @@ compareOnePair: [
     ] if
   ] if
 
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -170,11 +170,11 @@ compareOnePair: [
     copy currentName:;
     copy current:;
     copy prev:;
-  }] func;
+  }];
 
   WayInfo: [
     -1 dynamic -1 dynamic StringView makeWayInfo
-  ] func;
+  ];
 
   unfinishedStack: RefToVar Array;
   unfinishedCache: RefToVar Array;
@@ -270,7 +270,7 @@ getOverload: [
   ] [
     overload maxOverloadCountCur + maxOverloadCountNes -
   ] if
-] func;
+];
 
 tryMatchNode: [
   currentMatchingNode:;
@@ -337,7 +337,7 @@ tryMatchNode: [
         (s) addLog
         s compilerError
       ] call
-    ] func;
+    ];
 
     success: TRUE;
     i: 0 dynamic;
@@ -432,7 +432,7 @@ tryMatchNode: [
 
     success
   ] &&
-] func;
+];
 
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; forceRealFunction: Cond; indexArrayOfSubNode: IndexArray Cref;} Int32 {convention: cdecl;} [
   processorResult:;
@@ -474,11 +474,11 @@ tryMatchNode: [
 
 tryMatchAllNodes: [
   FALSE multiParserResult @currentNode indexOfNode @processor @processorResult tryMatchAllNodesWith
-] func;
+];
 
 tryMatchAllNodesForRealFunction: [
   TRUE multiParserResult @currentNode indexOfNode @processor @processorResult tryMatchAllNodesWith
-] func;
+];
 
 fixRecursionStack: [
   i: indexOfNode copy;
@@ -495,7 +495,7 @@ fixRecursionStack: [
       TRUE
     ] &&
   ] loop
-] func;
+];
 
 changeNewNodeState: [
   copy newNodeIndex:;
@@ -522,7 +522,7 @@ changeNewNodeState: [
       newNode.recursionState NodeRecursionStateFail > [newNode.state NodeStateHasOutput =] || [NodeStateHasOutput @currentNode.@state set] when
     ] if
   ] if
-] func;
+];
 
 changeNewExportNodeState: [
   copy newNodeIndex:;
@@ -549,7 +549,7 @@ changeNewExportNodeState: [
       newNode.recursionState NodeRecursionStateFail > [newNode.state NodeStateHasOutput =] || [NodeStateHasOutput @currentNode.@state set] when
     ] if
   ] if
-] func;
+];
 
 fixRef: [
   copy refToVar:;
@@ -603,7 +603,7 @@ fixRef: [
     ] when
   ] if
   refToVar
-] func;
+];
 
 applyOnePair: [
   cacheEntry:;
@@ -685,7 +685,7 @@ applyOnePair: [
       ] when
     ] if
   ] if
-] func;
+];
 
 applyEntriesRec: [
   cacheEntry:;
@@ -735,7 +735,7 @@ applyEntriesRec: [
       i 1 + @i set compilable
     ] &&
   ] loop
-] func;
+];
 
 fixOutputRefsRec: [
   stackEntry:;
@@ -773,7 +773,7 @@ fixOutputRefsRec: [
       i 1 + @i set compilable
     ] &&
   ] loop
-] func;
+];
 
 fixCaptureRef: [
   refToVar:;
@@ -801,7 +801,7 @@ fixCaptureRef: [
   ] loop
 
   result
-] func;
+];
 
 usePreCaptures: [
   compileOnce
@@ -829,7 +829,7 @@ usePreCaptures: [
       i 1 + @i set compilable
     ] &&
   ] loop
-] func;
+];
 
 applyNodeChanges: [
   compileOnce
@@ -941,7 +941,7 @@ applyNodeChanges: [
   ] each
 
   @appliedVars
-] func;
+];
 
 changeVarValue: [
   dst:;
@@ -967,7 +967,7 @@ changeVarValue: [
       ] when
     ] if
   ] when
-] func;
+];
 
 usePreInputs: [
   newNode:;
@@ -975,27 +975,27 @@ usePreInputs: [
   newMinStackDepth currentNode.minStackDepth < [
     newMinStackDepth @currentNode.@minStackDepth set
   ] when
-] func;
+];
 
 #useCapturesAsPreCaptures: [
 #  newNode:;
 #  newNode.captures [.value @currentNode.@preCaptures.pushBack] each
 #  newNode.fieldCaptures [.value @currentNode.@preFieldCaptures.pushBack] each
-#] func;
+#];
 
 #usePreCaptures: [
 #  newNode:;
 #  newNode.preCaptures [.value @currentNode.@preCaptures.pushBack] each
 #  newNode.preFieldCaptures [.value @currentNode.@preFieldCaptures.pushBack] each
-#] func;
+#];
 
-pushOutput: [push] func;
+pushOutput: [push];
 
 isImplicitDeref: [
   copy case:;
   case ArgReturnDeref =
   case ArgRefDeref = or
-] func;
+];
 
 derefNEntries: [
   copy count:;
@@ -1010,7 +1010,7 @@ derefNEntries: [
       i 1 + @i set TRUE
     ] &&
   ] loop
-] func;
+];
 
 applyNamedStackChanges: [
   forcedName:;
@@ -1054,12 +1054,12 @@ applyNamedStackChanges: [
     newNode.outputs [.value.argCase isImplicitDeref @implicitDerefInfo.pushBack] each
     implicitDerefInfo appliedVars.fixedOutputs.getSize derefNEntries
   ] when
-] func;
+];
 
 applyStackChanges: [
   forcedName: StringView;
   forcedName applyNamedStackChanges
-] func;
+];
 
 makeCallInstructionWith: [
   copy dynamicFunc:;
@@ -1164,18 +1164,18 @@ makeCallInstructionWith: [
       @retName argRet createStoreFromRegister
     ] when
   ] when
-] func;
+];
 
 makeNamedCallInstruction: [
   r: RefToVar;
   r FALSE dynamic makeCallInstructionWith
-] func;
+];
 
 makeCallInstruction: [
   r: RefToVar;
   forcedName: StringView;
   forcedName r FALSE dynamic makeCallInstructionWith
-] func;
+];
 
 processNamedCallByNode: [
   forcedName:;
@@ -1194,12 +1194,12 @@ processNamedCallByNode: [
 
     newNode newNodeIndex @appliedVars forcedName applyNamedStackChanges
   ] when
-] func;
+];
 
 processCallByNode: [
   forcedName: StringView;
   forcedName processNamedCallByNode
-] func;
+];
 
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   positionInfo: CompilerPositionInfo Cref; name: StringView Cref; nodeCase: NodeCaseCode; indexArray: IndexArray Cref;} () {convention: cdecl;} [
@@ -1449,7 +1449,7 @@ processIf: [
             ] [
               index branch.fixedOutputs.dataSize + longestOutputSize - branch.fixedOutputs.at copy
             ] if
-          ] func;
+          ];
 
           isOutputImplicitDeref: [
             branch:;
@@ -1459,7 +1459,7 @@ processIf: [
             ] [
               index branch.outputs.dataSize + longestOutputSize - branch.outputs.at.argCase isImplicitDeref
             ] if
-          ] func;
+          ];
 
           getCompiledInput: [
             compiledOutputs:;
@@ -1471,7 +1471,7 @@ processIf: [
             ] [
               index branch.outputs.dataSize + longestOutputSize - compiledOutputs.at copy
             ] if
-          ] func;
+          ];
 
           getCompiledOutput: [
             compiledOutputs:;
@@ -1482,7 +1482,7 @@ processIf: [
             ] [
               index branch.outputs.dataSize + longestOutputSize - compiledOutputs.at
             ] if
-          ] func;
+          ];
 
           # merge captures
           mergeValues: [
@@ -1504,7 +1504,7 @@ processIf: [
                 value2 makePointeeDirtyIfRef
               ] if
             ] if
-          ] func;
+          ];
 
           mergeValuesRec: [
             refToDst:;
@@ -1552,7 +1552,7 @@ processIf: [
                 TRUE
               ] &&
             ] loop
-          ] func;
+          ];
 
           appliedVarsThen.curToNested [
             pair:;
@@ -1664,7 +1664,7 @@ processIf: [
                   ] &&
                 ] loop
                 result
-              ] func;
+              ];
 
               0 refToCond createBranch
               createLabel
@@ -1687,9 +1687,9 @@ processIf: [
     ] when
   ] when
 
-] func;
+];
 
-maxLoopLength: [64 dynamic] func;
+maxLoopLength: [64 dynamic];
 
 processLoop: [
   astNode:;
@@ -1760,7 +1760,7 @@ processLoop: [
   ] loop
 
   loopIsDynamic [indexArray processDynamicLoop] when
-] func;
+];
 
 processDynamicLoop: [
 
@@ -1810,7 +1810,7 @@ processDynamicLoop: [
           ] if
 
           result
-        ] func;
+        ];
 
         appliedVars.curToNested [
           pair:;
@@ -1895,7 +1895,7 @@ processDynamicLoop: [
                 i 1 + @i set TRUE
               ] &&
             ] loop
-          ] func;
+          ];
 
           # create instruction
           processor.options.verboseIR ["loop prepare..." makeStringView createComent] when
@@ -1931,7 +1931,7 @@ processDynamicLoop: [
       ] if
     ] &&
   ] loop
-] func;
+];
 
 nSwap: [
   copy n:;
@@ -1947,7 +1947,7 @@ nSwap: [
     i 1 + @i set
     j 1 - @j set
   ] while
-] func;
+];
 
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   asLambda: Cond; name: StringView Cref; astNode: AstNode Cref; signature: CFunctionSignature Cref;} Int32 {convention: cdecl;} [
@@ -2227,9 +2227,9 @@ callImportWith: [
       implicitDerefInfo outputs.getSize derefNEntries
     ]
   ) sequence
-] func;
+];
 
-callImport: [RefToVar FALSE dynamic callImportWith] func;
+callImport: [RefToVar FALSE dynamic callImportWith];
 
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   refToVar: RefToVar Cref;} () {convention: cdecl;} [

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -262,7 +262,7 @@ getOverload: [
   cap:;
   overload: cap.nameOverload copy;
   maxOverloadCountCur: cap.nameInfo getOverloadCount;
-  maxOverloadCountNes: cap.cntNameOverload copy;
+  maxOverloadCountNes: cap.cntNameOverloadParent copy;
   overload maxOverloadCountCur + maxOverloadCountNes < [
     ("while matching cant call overload for name: " cap.nameInfo processor.nameInfos.at.name) assembleString compilerError
     0

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -911,7 +911,7 @@ derefNEntries: [
   i: 0 dynamic;
   [
     i count < [
-      i implicitDerefInfo.at [
+      count 1 - i - implicitDerefInfo.at [
         dst: i getStackEntry;
         dst getPossiblePointee @dst set
       ] when

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -293,14 +293,14 @@ tryMatchNode: [
     [getStackDepth currentMatchingNode.matchingInfo.inputs.dataSize currentMatchingNode.matchingInfo.preInputs.dataSize + < not] &&
   ] &&;
 
-  goodReality: 
-    forceRealFunction not [
-      currentMatchingNode.nodeCase NodeCaseDeclaration =
-      [currentMatchingNode.nodeCase NodeCaseDllDeclaration =] ||
-      [currentMatchingNode.nodeCase NodeCaseCodeRefDeclaration =] ||
-      [currentMatchingNode.nodeCase NodeCaseExport =] ||
-      [currentMatchingNode.nodeCase NodeCaseLambda =] ||
-    ] ||;
+  goodReality:
+  forceRealFunction not [
+    currentMatchingNode.nodeCase NodeCaseDeclaration =
+    [currentMatchingNode.nodeCase NodeCaseDllDeclaration =] ||
+    [currentMatchingNode.nodeCase NodeCaseCodeRefDeclaration =] ||
+    [currentMatchingNode.nodeCase NodeCaseExport =] ||
+    [currentMatchingNode.nodeCase NodeCaseLambda =] ||
+  ] ||;
 
   invisibleName: currentMatchingNode.nodeCase NodeCaseLambda = [currentMatchingNode.varNameInfo 0 < not] && [
     matchingCapture: Capture;
@@ -1201,7 +1201,7 @@ processCallByNode: [
   forcedName processNamedCallByNode
 ] func;
 
-{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; 
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   positionInfo: CompilerPositionInfo Cref; name: StringView Cref; nodeCase: NodeCaseCode; indexArray: IndexArray Cref;} () {convention: cdecl;} [
 
   processorResult:;
@@ -1962,7 +1962,7 @@ nSwap: [
   name:;
   astNode:;
   signature:;
-  
+
   indexArray: AstNodeType.Code astNode.data.get;
   positionInfo: astNode makeCompilerPosition;
   compileOnce
@@ -2231,7 +2231,7 @@ callImportWith: [
 
 callImport: [RefToVar FALSE dynamic callImportWith] func;
 
-{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref; 
+{processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   refToVar: RefToVar Cref;} () {convention: cdecl;} [
 
   processorResult:;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -707,6 +707,8 @@ applyEntriesRec: [
       cacheEntryVar: currentFromCache getVar;
       stackEntryVar: currentFromStack getVar;
 
+      cacheEntryVar.capturedAsRealValue [currentFromStack makeVarRealCaptured] when
+
       cacheEntryVar.data.getTag VarRef = [currentFromCache staticnessOfVar Virtual <] && [currentFromCache staticnessOfVar Dynamic >] && [
         clearPointee: VarRef cacheEntryVar.data.get copy; # if captured, host index will be currentChangesNodeIndex
         clearPointee.hostId currentChangesNodeIndex = [ # we captured it
@@ -2161,6 +2163,7 @@ callImportWith: [
             [stackEntry: pop;]
             [
               input: stackEntry copy;
+              input makeVarRealCaptured
               nodeEntry: i declarationNode.matchingInfo.inputs.at.refToVar;
               nodeMutable: nodeEntry.mutable copy;
               i declarationNode.csignature.inputs.at getVar.data.getTag VarRef = [

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -2079,7 +2079,7 @@ nSwap: [
 
   signature.inputs [p:; a: pop;] each
 
-  oldSuccess compilable not and [
+  oldSuccess compilable not and processor.depthOfPre 0 = and [
     @processorResult.@errorInfo move @processorResult.@globalErrorInfo.pushBack
     oldRecursiveNodesStackSize @processor.@recursiveNodesStack.shrink
     -1 clearProcessorResult

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1247,9 +1247,13 @@ processPre: [
     newNodeIndex: indexArray tryMatchAllNodes;
     newNodeIndex 0 < [compilable] && [
       oldSuccess: compilable;
+      oldGlobalErrorCount: processorResult.globalErrorInfo.getSize;
+
       processor.depthOfPre 1 + @processor.@depthOfPre set
       "PRE" makeStringView indexOfNode NodeCaseCode  @processorResult @processor indexArray multiParserResult positionInfo CFunctionSignature astNodeToCodeNode @newNodeIndex set
       processor.depthOfPre 1 - @processor.@depthOfPre set
+
+      oldGlobalErrorCount @processorResult.@globalErrorInfo.shrink
 
       oldSuccess [
         processor.maxDepthExceeded not [
@@ -1900,11 +1904,13 @@ processExportFunction: [
     "export function cannot be variadic" compilerError
   ] when
 
+  oldSuccess: compilable;
   newNodeIndex: @indexArray TRUE dynamic tryMatchAllNodesWith;
   newNodeIndex 0 < [compilable] && [
     nodeCase: asLambda [NodeCaseLambda][NodeCaseExport] if;
     processor.processingExport 1 + @processor.@processingExport set
     name indexOfNode nodeCase @processorResult @processor indexArray multiParserResult positionInfo signature astNodeToCodeNode @newNodeIndex set
+
     processor.processingExport 1 - @processor.@processingExport set
   ] when
 
@@ -1944,6 +1950,12 @@ processExportFunction: [
         ] when
       ] each
     ] when
+  ] when
+
+  oldSuccess compilable not and [
+    @processorResult.@errorInfo move @processorResult.@globalErrorInfo.pushBack
+    ProcessorErrorInfo @processorResult.@errorInfo set
+    TRUE dynamic @processorResult.@success set
   ] when
 
   signature.inputs [p:; a: pop;] each

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -712,7 +712,7 @@ fixCaptureRef: [
   result
 ] func;
 
-applyPreNodeCaptures: [
+usePreCaptures: [
   compileOnce
   currentChangesNode:;
 
@@ -760,6 +760,7 @@ applyNodeChanges: [
     i currentChangesNode.matchingInfo.inputs.dataSize < [
       stackEntry: popForMatching;
       cacheEntry: i currentChangesNode.matchingInfo.inputs.at.refToVar;
+
       stackEntry cacheEntry applyEntriesRec
       stackEntry @pops.pushBack
 
@@ -1222,7 +1223,7 @@ processPre: [
 
     newNode: newNodeIndex processor.nodes.at.get;
     newNode usePreInputs
-    newNode applyPreNodeCaptures
+    newNode usePreCaptures
     #newNode useCapturesAsPreCaptures
     #newNode usePreCaptures
 
@@ -1882,6 +1883,13 @@ processExportFunction: [
           fr.success [TRUE @fr.@value.@used set] when
         ] when
       ] each
+
+      newNode usePreCaptures
+
+      #newNode.matchingInfo.captures [
+      #  capture: .value;
+      #  ("capture; name=" capture.nameInfo processor.nameInfos.at.name "; ctype=" capture.refToVar getMplType) addLog
+      #] each
 
       signature.outputs [
         pair:;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -2042,6 +2042,8 @@ nSwap: [
     @processorResult.@errorInfo move @processorResult.@globalErrorInfo.pushBack
     oldRecursiveNodesStackSize @processor.@recursiveNodesStack.shrink
     -1 clearProcessorResult
+
+    signature name FALSE dynamic processImportFunction !newNodeIndex
   ] when
 
   signature.inputs [p:; a: pop;] each

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -2079,6 +2079,8 @@ nSwap: [
     ] when
   ] when
 
+  signature.inputs [p:; a: pop;] each
+
   oldSuccess compilable not and [
     @processorResult.@errorInfo move @processorResult.@globalErrorInfo.pushBack
     oldRecursiveNodesStackSize @processor.@recursiveNodesStack.shrink
@@ -2087,7 +2089,6 @@ nSwap: [
     signature name FALSE dynamic processImportFunction !newNodeIndex
   ] when
 
-  signature.inputs [p:; a: pop;] each
   ("processed export: " makeStringView name makeStringView) addLog
 
   newNodeIndex

--- a/processor.mpl
+++ b/processor.mpl
@@ -8,9 +8,9 @@ CompilerPositionInfo: [{
   offset:     -1 dynamic;
   fileNumber: 0 dynamic;
   token:      String;
-}] func;
+}];
 
-StringArray: [String Array] func;
+StringArray: [String Array];
 
 ProcessorOptions: [{
   mainPath:       String;
@@ -23,13 +23,13 @@ ProcessorOptions: [{
   logs:           FALSE dynamic;
   verboseIR:      FALSE dynamic;
   linkerOptions:  String Array;
-}] func;
+}];
 
 ProcessorErrorInfo: [{
   message: String;
   missedModule: String;
   position: CompilerPositionInfo Array;
-}] func;
+}];
 
 ProcessorResult: [{
   success: TRUE dynamic;
@@ -38,29 +38,29 @@ ProcessorResult: [{
   program: String;
   errorInfo: ProcessorErrorInfo;
   globalErrorInfo: ProcessorErrorInfo Array;
-}] func;
+}];
 
 makeInstruction: [{
   enabled: TRUE dynamic;
   alloca: FALSE dynamic;
   fakePointer: FALSE dynamic;
   code: copy;
-}] func;
+}];
 
-Instruction: [String makeInstruction] func;
+Instruction: [String makeInstruction];
 
-ArgVirtual:       [0n8 dynamic] func;
-ArgGlobal:        [1n8 dynamic] func;
-ArgRef:           [2n8 dynamic] func;
-ArgCopy:          [3n8 dynamic] func;
-ArgReturn:        [4n8 dynamic] func;
-ArgRefDeref:      [5n8 dynamic] func;
-ArgReturnDeref:   [6n8 dynamic] func;
+ArgVirtual:       [0n8 dynamic];
+ArgGlobal:        [1n8 dynamic];
+ArgRef:           [2n8 dynamic];
+ArgCopy:          [3n8 dynamic];
+ArgReturn:        [4n8 dynamic];
+ArgRefDeref:      [5n8 dynamic];
+ArgReturnDeref:   [6n8 dynamic];
 
 Argument: [{
   refToVar: RefToVar;
   argCase: ArgRef;
-}] func;
+}];
 
 Capture: [{
   refToVar: RefToVar;
@@ -69,7 +69,7 @@ Capture: [{
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
   cntNameOverload: -1 dynamic;
-}] func;
+}];
 
 FieldCapture: [{
   object: RefToVar;
@@ -78,47 +78,47 @@ FieldCapture: [{
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
   cntNameOverload: -1 dynamic;
-}] func;
+}];
 
 IndexInfo: [{
   overload: -1 dynamic;
   index: -1 dynamic;
-}] func;
+}];
 
-IndexInfoArray: [IndexInfo Array] func;
+IndexInfoArray: [IndexInfo Array];
 
-NodeCaseEmpty:                 [0n8 dynamic] func;
-NodeCaseCode:                  [1n8 dynamic] func;
-NodeCaseDtor:                  [2n8 dynamic] func;
-NodeCaseDeclaration:           [3n8 dynamic] func;
-NodeCaseDllDeclaration:        [4n8 dynamic] func;
-NodeCaseCodeRefDeclaration:    [5n8 dynamic] func;
-NodeCaseExport:                [6n8 dynamic] func;
-NodeCaseLambda:                [7n8 dynamic] func;
-NodeCaseList:                  [8n8 dynamic] func;
-NodeCaseObject:                [9n8 dynamic] func;
+NodeCaseEmpty:                 [0n8 dynamic];
+NodeCaseCode:                  [1n8 dynamic];
+NodeCaseDtor:                  [2n8 dynamic];
+NodeCaseDeclaration:           [3n8 dynamic];
+NodeCaseDllDeclaration:        [4n8 dynamic];
+NodeCaseCodeRefDeclaration:    [5n8 dynamic];
+NodeCaseExport:                [6n8 dynamic];
+NodeCaseLambda:                [7n8 dynamic];
+NodeCaseList:                  [8n8 dynamic];
+NodeCaseObject:                [9n8 dynamic];
 
-NodeStateNew:         [0n8 dynamic] func;
-NodeStateNoOutput:    [1n8 dynamic] func; #after calling NodeStateNew recursion with unknown output, node is uncompilable
-NodeStateHasOutput:   [2n8 dynamic] func; #after merging "if" with output and without output, node can be compiled
-NodeStateCompiled:    [3n8 dynamic] func; #node finished
+NodeStateNew:         [0n8 dynamic];
+NodeStateNoOutput:    [1n8 dynamic]; #after calling NodeStateNew recursion with unknown output, node is uncompilable
+NodeStateHasOutput:   [2n8 dynamic]; #after merging "if" with output and without output, node can be compiled
+NodeStateCompiled:    [3n8 dynamic]; #node finished
 
-NodeRecursionStateNo:       [0n8 dynamic] func;
-NodeRecursionStateFail:     [1n8 dynamic] func;
-NodeRecursionStateNew:      [2n8 dynamic] func;
-NodeRecursionStateOld:      [3n8 dynamic] func;
-NodeRecursionStateFailDone: [4n8 dynamic] func;
+NodeRecursionStateNo:       [0n8 dynamic];
+NodeRecursionStateFail:     [1n8 dynamic];
+NodeRecursionStateNew:      [2n8 dynamic];
+NodeRecursionStateOld:      [3n8 dynamic];
+NodeRecursionStateFailDone: [4n8 dynamic];
 
 CaptureNameResult: [{
   refToVar: RefToVar;
   object: RefToVar;
-}] func;
+}];
 
 NameWithOverload: [{
   virtual NAME_WITH_OVERLOAD: ();
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
-}] func;
+}];
 
 NameWithOverloadAndRefToVar: [{
   virtual NAME_WITH_OVERLOAD_AND_REF_TO_VAR: ();
@@ -126,7 +126,7 @@ NameWithOverloadAndRefToVar: [{
   nameOverload: -1 dynamic;
   refToVar: RefToVar;
   startPoint: -1 dynamic;
-}] func;
+}];
 
 =: ["NAME_WITH_OVERLOAD" has] [
   n1:; n2:;
@@ -140,33 +140,33 @@ hash: ["NAME_WITH_OVERLOAD" has] [
 
 RefToVarTable: [
   RefToVar RefToVar HashTable
-] func;
+];
 
 NameTable:  [
   elementConstructor:;
   NameWithOverload @elementConstructor HashTable
-] func;
+];
 
-IntTable: [Int32 Int32 HashTable] func;
+IntTable: [Int32 Int32 HashTable];
 
 MatchingInfo: [{
   inputs: Argument Array;
   preInputs: RefToVar Array;
   captures: Capture Array;
   fieldCaptures: FieldCapture Array;
-}] func;
+}];
 
 CFunctionSignature: [{
   inputs: RefToVar Array;
   outputs: RefToVar Array;
   variadic: FALSE dynamic;
   convention: String;
-}] func;
+}];
 
 UsedModuleInfo: [{
   used: FALSE dynamic;
   position: CompilerPositionInfo;
-}] func;
+}];
 
 CodeNode: [{
   root: FALSE dynamic;
@@ -236,7 +236,7 @@ CodeNode: [{
 
   INIT: [];
   DIE: [];
-}] func;
+}];
 
 Processor: [{
   options: ProcessorOptions;
@@ -313,4 +313,4 @@ Processor: [{
 
   INIT: [];
   DIE: [];
-}] func;
+}];

--- a/processor.mpl
+++ b/processor.mpl
@@ -33,6 +33,7 @@ ProcessorErrorInfo: [{
 ProcessorResult: [{
   success: TRUE dynamic;
   findModuleFail: FALSE dynamic;
+  maxDepthExceeded: FALSE dynamic;
   program: String;
   errorInfo: ProcessorErrorInfo;
   globalErrorInfo: ProcessorErrorInfo Array;
@@ -308,7 +309,6 @@ Processor: [{
 
   usedFloatBuiltins: FALSE dynamic;
   usedHeapBuiltins: FALSE dynamic;
-  maxDepthExceeded: FALSE dynamic;
 
   INIT: [];
   DIE: [];

--- a/processor.mpl
+++ b/processor.mpl
@@ -3,11 +3,11 @@
 "astNodeType" includeModule
 
 CompilerPositionInfo: [{
-  column: -1 dynamic;
-  line: -1 dynamic;
-  offset: -1 dynamic;
-  filename: 0 dynamic;
-  token: String;
+  column:     -1 dynamic;
+  line:       -1 dynamic;
+  offset:     -1 dynamic;
+  fileNumber: 0 dynamic;
+  token:      String;
 }] func;
 
 StringArray: [String Array] func;

--- a/processor.mpl
+++ b/processor.mpl
@@ -35,6 +35,7 @@ ProcessorResult: [{
   findModuleFail: FALSE dynamic;
   program: String;
   errorInfo: ProcessorErrorInfo;
+  globalErrorInfo: ProcessorErrorInfo Array;
 }] func;
 
 makeInstruction: [{

--- a/processor.mpl
+++ b/processor.mpl
@@ -1,5 +1,6 @@
 "processor" module
-"control" useModule
+"control" includeModule
+"astNodeType" includeModule
 
 CompilerPositionInfo: [{
   column: -1 dynamic;

--- a/processor.mpl
+++ b/processor.mpl
@@ -69,6 +69,7 @@ Capture: [{
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
   cntNameOverload: -1 dynamic;
+  cntNameOverloadParent: -1 dynamic;
 }];
 
 FieldCapture: [{
@@ -78,6 +79,7 @@ FieldCapture: [{
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
   cntNameOverload: -1 dynamic;
+  cntNameOverloadParent: -1 dynamic;
 }];
 
 IndexInfo: [{
@@ -124,6 +126,8 @@ NameWithOverloadAndRefToVar: [{
   virtual NAME_WITH_OVERLOAD_AND_REF_TO_VAR: ();
   nameInfo: -1 dynamic;
   nameOverload: -1 dynamic;
+  cntNameOverload: -1 dynamic;
+  cntNameOverloadParent: -1 dynamic;
   refToVar: RefToVar;
   startPoint: -1 dynamic;
 }];

--- a/processor.mpl
+++ b/processor.mpl
@@ -309,7 +309,6 @@ Processor: [{
   deletedVarCount: 0 dynamic;
 
   usedFloatBuiltins: FALSE dynamic;
-  usedHeapBuiltins: FALSE dynamic;
 
   INIT: [];
   DIE: [];

--- a/processor.mpl
+++ b/processor.mpl
@@ -175,6 +175,8 @@ CodeNode: [{
   program: Instruction Array;
   aliases: String Array;
   variables: Variable Owner Array; # as unique_ptr...
+  lastLambdaName: Int32;
+  nextRecLambdaId: -1 dynamic;
 
   nodeIsRecursive: FALSE dynamic;
   nextLabelIsVirtual: FALSE dynamic;

--- a/processor.mpl
+++ b/processor.mpl
@@ -206,6 +206,7 @@ CodeNode: [{
   uncompilable: FALSE dynamic;
   variadic: FALSE dynamic;
 
+  countOfUCall: 0 dynamic;
   declarationRefs: Cond Array;
   buildingMatchingInfo: MatchingInfo;
   matchingInfo: MatchingInfo;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -44,6 +44,18 @@ failProcForProcessor: [
   refToVar: RefToVar Cref;
 } () {convention: cdecl;} "createDtorForGlobalVar" importFunction
 
+clearProcessorResult: [
+  copy cachedGlobalErrorInfoSize:;
+  TRUE dynamic              @processorResult.@success set
+  FALSE dynamic             @processorResult.@findModuleFail set
+  FALSE dynamic             @processorResult.@maxDepthExceeded set
+  String                    @processorResult.@program set
+  ProcessorErrorInfo        @processorResult.@errorInfo set
+  cachedGlobalErrorInfoSize 0 < not [
+    cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
+  ] when
+] func;
+
 processImpl: [
   processorResult:;
   copy unitId:;
@@ -121,14 +133,6 @@ processImpl: [
     dependedFiles: String IndexArray HashTable; # string -> array of indexes of dependent files
     cachedGlobalErrorInfoSize: 0;
 
-    clearProcessorResult: [
-      TRUE dynamic              @processorResult.@success set
-      FALSE dynamic             @processorResult.@findModuleFail set
-      String                    @processorResult.@program set
-      ProcessorErrorInfo        @processorResult.@errorInfo set
-      cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
-    ] func;
-
     runFile: [
       copy n:;
       n @lastFile set
@@ -153,7 +157,7 @@ processImpl: [
           @processorResult.@errorInfo.@missedModule @a move @dependedFiles.insert
         ] if
 
-        clearProcessorResult
+        cachedGlobalErrorInfoSize clearProcessorResult
       ] [
         ("compiled file " n processor.options.fileNames.at) addLog
         # call files which depends from this module
@@ -208,7 +212,7 @@ processImpl: [
         lastFile correctUnitInfo
       ] when
 
-      clearProcessorResult
+      0 clearProcessorResult
 
       dependedFiles.getSize 0 > [
         hasError: FALSE dynamic;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -101,7 +101,7 @@
       1 dynamic @rootPositionInfo.@column set
       1 dynamic @rootPositionInfo.@line set
       0 dynamic @rootPositionInfo.@offset set
-      n dynamic @rootPositionInfo.@filename set
+      n dynamic @rootPositionInfo.@fileNumber set
 
       processorResult.globalErrorInfo.getSize @cachedGlobalErrorInfoSize set
       topNodeIndex: StringView 0 NodeCaseCode @processorResult @processor fileNodes multiParserResult rootPositionInfo CFunctionSignature astNodeToCodeNode;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -96,7 +96,7 @@
     runFile: [
       copy n:;
       n @lastFile set
-      fileNodes:  n multiParserResult.nodes.at;
+      fileNode: n multiParserResult.nodes.at;
       rootPositionInfo: CompilerPositionInfo;
       1 dynamic @rootPositionInfo.@column set
       1 dynamic @rootPositionInfo.@line set
@@ -104,7 +104,7 @@
       n dynamic @rootPositionInfo.@fileNumber set
 
       processorResult.globalErrorInfo.getSize @cachedGlobalErrorInfoSize set
-      topNodeIndex: StringView 0 NodeCaseCode @processorResult @processor fileNodes multiParserResult rootPositionInfo CFunctionSignature astNodeToCodeNode;
+      topNodeIndex: StringView 0 NodeCaseCode @processorResult @processor fileNode multiParserResult rootPositionInfo CFunctionSignature astNodeToCodeNode;
 
       processorResult.findModuleFail [
         # cant compile this file now, add him to queue
@@ -194,6 +194,7 @@
         hasError [hasErrorMessage not] && [
           String @processorResult.@errorInfo.@message set
           "problem with finding modules" @processorResult.@errorInfo.@message.cat
+
           LF @processorResult.@errorInfo.@message.cat
           dependedFiles [
             # queue is empty, but has uncompiled files

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -11,52 +11,12 @@
 "processor" useModule
 "irWriter" useModule
 
-failProcForProcessor: [
-  failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr] func;
-  copy message:;
-  "ASSERTION FAILED!!!" print LF print
-  message print LF print
-  "While compiling:" print LF print
-  mplBuiltinPrintStackTrace
-
-  "Terminating..." print LF print
-  2 exit
-] func;
-
 {
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
-  multiParserResult: MultiParserResult Cref;
-  indexArray: IndexArray Cref;
-  processor: Processor Ref;
   processorResult: ProcessorResult Ref;
-  nodeCase: NodeCaseCode;
-  parentIndex: 0;
-  functionName: StringView Cref;
-} 0 {convention: cdecl;} "astNodeToCodeNode" importFunction
-
-{
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
+  unitId: 0;
+  options: ProcessorOptions Cref;
   multiParserResult: MultiParserResult Cref;
-  processor: Processor Ref;
-  processorResult: ProcessorResult Ref;
-  refToVar: RefToVar Cref;
-} () {convention: cdecl;} "createDtorForGlobalVar" importFunction
-
-clearProcessorResult: [
-  copy cachedGlobalErrorInfoSize:;
-  TRUE dynamic              @processorResult.@success set
-  FALSE dynamic             @processorResult.@findModuleFail set
-  FALSE dynamic             @processorResult.@maxDepthExceeded set
-  String                    @processorResult.@program set
-  ProcessorErrorInfo        @processorResult.@errorInfo set
-  cachedGlobalErrorInfoSize 0 < not [
-    cachedGlobalErrorInfoSize @processorResult.@globalErrorInfo.shrink
-  ] when
-] func;
-
-processImpl: [
+} () {convention: cdecl;} [
   processorResult:;
   copy unitId:;
   options:;
@@ -337,57 +297,16 @@ processImpl: [
       ] when
     ] each
   ] when
-] func;
-
-{
-  processorResult: ProcessorResult Ref;
-  unitId: 0;
-  options: ProcessorOptions Cref;
-  multiParserResult: MultiParserResult Cref;
-} () {convention: cdecl;} [
-  processorResult:;
-  unitId:;
-  options:;
-  multiParserResult:;
-  multiParserResult
-  options
-  unitId
-  @processorResult processImpl
 ] "process" exportFunction
 
 {
   signature: CFunctionSignature Cref;
   compilerPositionInfo: CompilerPositionInfo Cref;
   multiParserResult: MultiParserResult Cref;
-  indexArray: IndexArray Cref;
   processor: Processor Ref;
   processorResult: ProcessorResult Ref;
-  nodeCase: NodeCaseCode;
-  parentIndex: 0;
-  functionName: StringView Cref;
-} 0 {convention: cdecl;}  [
-  signature:;
-  compilerPositionInfo:;
-  multiParserResult:;
-  indexArray:;
-  processor:;
-  processorResult:;
-  nodeCase:;
-  parentIndex:;
-  functionName:;
-
-  functionName
-  parentIndex
-  nodeCase
-  @processorResult
-  @processor
-  indexArray
-  multiParserResult
-  compilerPositionInfo
-  signature astNodeToCodeNodeImpl
-] "astNodeToCodeNode" exportFunction
-
-createDtorForGlobalVarImpl: [
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} [
   forcedSignature:;
   compilerPositionInfo:;
   multiParserResult:;
@@ -421,21 +340,4 @@ createDtorForGlobalVarImpl: [
   dtorName: ("dtor." refToVar getVar.globalId) assembleString;
   dtorNameStringView: dtorName makeStringView;
   dtorNameStringView finalizeCodeNode
-] func;
-
-{
-  signature: CFunctionSignature Cref;
-  compilerPositionInfo: CompilerPositionInfo Cref;
-  multiParserResult: MultiParserResult Cref;
-  processor: Processor Ref;
-  processorResult: ProcessorResult Ref;
-  refToVar: RefToVar Cref;
-} () {convention: cdecl;} [
-  forcedSignature:;
-  compilerPositionInfo:;
-  multiParserResult:;
-  processor:;
-  processorResult:;
-  refToVar:;
-  refToVar @processorResult @processor multiParserResult compilerPositionInfo forcedSignature createDtorForGlobalVarImpl
 ] "createDtorForGlobalVar" exportFunction

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -238,7 +238,6 @@
     ("max depth of recursion=" processor.maxDepthOfRecursion) addLog
 
     processor.usedFloatBuiltins [createFloatBuiltins] when
-    processor.usedHeapBuiltins  [createHeapBuiltins] when
     createCtors
     createDtors
     clearUnusedDebugInfo

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -84,8 +84,6 @@
     ] loop
   ] when
 
-  #("compiled file " makeStringView n processor.options.fileNames.at makeStringView) addLog
-
   lastFile: 0 dynamic;
 
   multiParserResult.nodes.dataSize 0 > [
@@ -217,22 +215,6 @@
   [compilable not [processor.recursiveNodesStack.getSize 0 =] ||] "Recursive stack is not empty!" assert
 
   processorResult.success [
-    #("; total used="           memoryUsed
-    # "; varCount="             processor.varCount
-    # "; structureVarCount="    processor.structureVarCount
-    # "; fieldVarCount="        processor.fieldVarCount
-    # "; nodeCount="            processor.nodeCount
-    # "; varSize="              Variable storageSize
-    # "; fieldSize="            Field storageSize
-    # "; structureSize="        Struct   storageSize
-    # "; refToVarSize="         RefToVar storageSize
-    # "; nodeSize="             CodeNode storageSize
-    # "; used in nodes="        processor.nodes getHeapUsedSize
-    # "; memoryCounterMalloc="  memoryCounterMalloc
-    # "; memoryCounterFree="    memoryCounterFree
-    # "; deletedVarCount="      processor.deletedVarCount
-    # "; deletedNodeCount="     processor.deletedNodeCount) addLog
-
     ("nameCount=" processor.nameInfos.dataSize
       "; irNameCount=" processor.nameBuffer.dataSize) addLog
 
@@ -274,9 +256,6 @@
                 curInstruction.code makeStringView @processorResult.@program.cat
                 LF @processorResult.@program.cat
               ] [
-                #" ; -> disabled: " makeStringView @processorResult.@program.cat
-                #curInstruction.code makeStringView @processorResult.@program.cat
-                #LF makeStringView @processorResult.@program.cat
               ] if
             ] each
             "}" @processorResult.@program.cat

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -139,7 +139,7 @@
 
         ] when
       ] if
-    ] func;
+    ];
 
     unfinishedFiles: IndexArray;
     n: 0 dynamic;

--- a/staticCall.mpl
+++ b/staticCall.mpl
@@ -44,4 +44,4 @@ staticCall: [
       ] if
     ] if
   ] if
-] func;
+];

--- a/variable.mpl
+++ b/variable.mpl
@@ -8,40 +8,40 @@
 "debugWriter" includeModule
 "processor"   includeModule
 
-Dirty:           [0n8 dynamic] func;
-Dynamic:         [1n8 dynamic] func;
-Weak:            [2n8 dynamic] func;
-Static:          [3n8 dynamic] func;
-Virtual:         [4n8 dynamic] func;
+Dirty:           [0n8 dynamic];
+Dynamic:         [1n8 dynamic];
+Weak:            [2n8 dynamic];
+Static:          [3n8 dynamic];
+Virtual:         [4n8 dynamic];
 
-NameCaseInvalid:               [ 0n8 dynamic] func;
-NameCaseBuiltin:               [ 1n8 dynamic] func;
-NameCaseLocal:                 [ 2n8 dynamic] func;
-NameCaseFromModule:            [ 3n8 dynamic] func;
-NameCaseCapture:               [ 4n8 dynamic] func;
+NameCaseInvalid:               [ 0n8 dynamic];
+NameCaseBuiltin:               [ 1n8 dynamic];
+NameCaseLocal:                 [ 2n8 dynamic];
+NameCaseFromModule:            [ 3n8 dynamic];
+NameCaseCapture:               [ 4n8 dynamic];
 
-NameCaseSelfMember:            [ 5n8 dynamic] func;
-NameCaseClosureMember:         [ 6n8 dynamic] func;
-NameCaseSelfObject:            [ 7n8 dynamic] func;
-NameCaseClosureObject:         [ 8n8 dynamic] func;
-NameCaseSelfObjectCapture:     [ 9n8 dynamic] func;
-NameCaseClosureObjectCapture:  [10n8 dynamic] func;
+NameCaseSelfMember:            [ 5n8 dynamic];
+NameCaseClosureMember:         [ 6n8 dynamic];
+NameCaseSelfObject:            [ 7n8 dynamic];
+NameCaseClosureObject:         [ 8n8 dynamic];
+NameCaseSelfObjectCapture:     [ 9n8 dynamic];
+NameCaseClosureObjectCapture:  [10n8 dynamic];
 
-MemberCaseToObjectCase:        [2n8 +] func;
-MemberCaseToObjectCaptureCase: [4n8 +] func;
+MemberCaseToObjectCase:        [2n8 +];
+MemberCaseToObjectCaptureCase: [4n8 +];
 
-ShadowReasonNo:      [0n8 dynamic] func;
-ShadowReasonCapture: [1n8 dynamic] func;
-ShadowReasonInput:   [2n8 dynamic] func;
-ShadowReasonField:   [3n8 dynamic] func;
-ShadowReasonPointee: [4n8 dynamic] func;
+ShadowReasonNo:      [0n8 dynamic];
+ShadowReasonCapture: [1n8 dynamic];
+ShadowReasonInput:   [2n8 dynamic];
+ShadowReasonField:   [3n8 dynamic];
+ShadowReasonPointee: [4n8 dynamic];
 
 RefToVar: [{
   virtual REF_TO_VAR: ();
   varId: -1 dynamic;
   hostId: -1 dynamic;
   mutable: TRUE dynamic;
-}] func;
+}];
 
 =: ["REF_TO_VAR" has] [
   refsAreEqual
@@ -56,46 +56,46 @@ NameInfoEntry: [{
   refToVar: RefToVar;
   startPoint: -1 dynamic; # id of node
   nameCase: NameCaseInvalid;
-}] func;
+}];
 
-Overload: [NameInfoEntry Array] func;
+Overload: [NameInfoEntry Array];
 
 makeNameInfo: [{
   name: copy;
   stack: Overload Array;
-}] func;
+}];
 
-NameInfo: [String makeNameInfo] func;
+NameInfo: [String makeNameInfo];
 
-VarInvalid: [ 0 static] func;
-VarCond:    [ 1 static] func;
-VarNat8:    [ 2 static] func;
-VarNat16:   [ 3 static] func;
-VarNat32:   [ 4 static] func;
-VarNat64:   [ 5 static] func;
-VarNatX:    [ 6 static] func;
-VarInt8:    [ 7 static] func;
-VarInt16:   [ 8 static] func;
-VarInt32:   [ 9 static] func;
-VarInt64:   [10 static] func;
-VarIntX:    [11 static] func;
-VarReal32:  [12 static] func;
-VarReal64:  [13 static] func;
-VarCode:    [14 static] func;
-VarBuiltin: [15 static] func;
-VarImport:  [16 static] func;
-VarString:  [17 static] func;
-VarRef:     [18 static] func;
-VarStruct:  [19 static] func;
-VarEnd:     [20 static] func;
+VarInvalid: [ 0 static];
+VarCond:    [ 1 static];
+VarNat8:    [ 2 static];
+VarNat16:   [ 3 static];
+VarNat32:   [ 4 static];
+VarNat64:   [ 5 static];
+VarNatX:    [ 6 static];
+VarInt8:    [ 7 static];
+VarInt16:   [ 8 static];
+VarInt32:   [ 9 static];
+VarInt64:   [10 static];
+VarIntX:    [11 static];
+VarReal32:  [12 static];
+VarReal64:  [13 static];
+VarCode:    [14 static];
+VarBuiltin: [15 static];
+VarImport:  [16 static];
+VarString:  [17 static];
+VarRef:     [18 static];
+VarStruct:  [19 static];
+VarEnd:     [20 static];
 
 Field: [{
   nameInfo: -1 dynamic; # NameInfo id
   nameOverload: -1 dynamic;
   refToVar: RefToVar;
-}] func;
+}];
 
-FieldArray: [Field Array] func;
+FieldArray: [Field Array];
 
 Struct: [{
   fullVirtual:   FALSE dynamic;
@@ -109,7 +109,7 @@ Struct: [{
   structName: NameWithOverload; # for overloads
   structStorageSize: 0nx dynamic;
   structAlignment: 0nx dynamic;
-}] func; #IDs of pointee vars
+}]; #IDs of pointee vars
 
 Variable: [{
   VARIABLE: ();
@@ -163,9 +163,9 @@ Variable: [{
 
   INIT: [];
   DIE: [];
-}] func;
+}];
 
-compilable: [processorResult.success copy] func;
+compilable: [processorResult.success copy];
 
 {
   signature: CFunctionSignature Cref;
@@ -311,7 +311,7 @@ compilable: [processorResult.success copy] func;
 
 makeVariableType: [
   multiParserResult @currentNode indexOfNode @processor @processorResult makeVariableTypeImpl
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -324,14 +324,14 @@ makeVariableType: [
 
 compilerError: [
   makeStringView multiParserResult @currentNode indexOfNode @processor @processorResult compilerErrorImpl
-] func;
+];
 
 
 # these functions require capture "processor"
 variableIsDeleted: [
   refToVar:;
   refToVar.varId refToVar.hostId @processor.@nodes.at.get.@variables.at.assigned not
-] func;
+];
 
 getVar: [
   refToVar:;
@@ -358,14 +358,14 @@ getVar: [
   ] "Wrong refToVar!" assert
 
   refToVar.varId refToVar.hostId @processor.@nodes.at.get.@variables.at.get
-] func;
+];
 
-getNameById: [processor.nameBuffer.at makeStringView] func;
-getMplName:  [getVar.mplNameId getNameById] func;
-getIrName:   [getVar.irNameId getNameById] func;
-getMplType:  [getVar.mplTypeId getNameById] func;
-getIrType:   [getVar.irTypeId getNameById] func;
-getDbgType:  [getVar.dbgTypeId getNameById] func;
+getNameById: [processor.nameBuffer.at makeStringView];
+getMplName:  [getVar.mplNameId getNameById];
+getIrName:   [getVar.irNameId getNameById];
+getMplType:  [getVar.mplTypeId getNameById];
+getIrType:   [getVar.irTypeId getNameById];
+getDbgType:  [getVar.dbgTypeId getNameById];
 
 getDebugType: [
   dbgType: getDbgType;
@@ -381,7 +381,7 @@ getDebugType: [
   result: (dbgType hash ".") assembleString;
   splitted.chars @result.catMany
   @result
-] func;
+];
 
 deepPrintVar: [
   refToVar:;
@@ -415,32 +415,32 @@ deepPrintVar: [
       ] &&
     ] loop
   ] when
-] func;
+];
 
 staticnessOfVar: [
   refToVar:;
   var: refToVar getVar;
   var.staticness copy
-] func;
+];
 
 maxStaticness: [
   copy s1:;
   copy s2:;
   s1 s2 > [s1 copy][s2 copy] if
-] func;
+];
 
 refsAreEqual: [
   refToVar1:;
   refToVar2:;
   refToVar1.hostId refToVar2.hostId = [refToVar1.varId refToVar2.varId =] &&
-] func;
+];
 
 variablesAreSame: [
   refToVar1:;
   refToVar2:;
   #refToVar1 getVar.mplType makeStringView refToVar2 getVar.mplType makeStringView stringCompare
   refToVar1 getVar.mplTypeId refToVar2 getVar.mplTypeId = # id compare better than string compare!
-] func;
+];
 
 isInt: [
   var: getVar;
@@ -449,7 +449,7 @@ isInt: [
   [var.data.getTag VarInt32 =] ||
   [var.data.getTag VarInt64 =] ||
   [var.data.getTag VarIntX =] ||
-] func;
+];
 
 isNat: [
   var: getVar;
@@ -458,25 +458,25 @@ isNat: [
   [var.data.getTag VarNat32 =] ||
   [var.data.getTag VarNat64 =] ||
   [var.data.getTag VarNatX =] ||
-] func;
+];
 
 isAnyInt: [
   refToVar:;
   refToVar isInt
   [ refToVar isNat ] ||
-] func;
+];
 
 isReal: [
   var: getVar;
   var.data.getTag VarReal32 =
   [var.data.getTag VarReal64 =] ||
-] func;
+];
 
 isNumber: [
   refToVar:;
   refToVar isReal
   [refToVar isAnyInt] ||
-] func;
+];
 
 isPlain: [
   refToVar:;
@@ -484,7 +484,7 @@ isPlain: [
     var: refToVar getVar;
     var.data.getTag VarCond =
   ] ||
-] func;
+];
 
 isTinyArg: [
   refToVar:;
@@ -493,35 +493,35 @@ isTinyArg: [
     var.data.getTag VarRef =
     [var.data.getTag VarString =] ||
   ] ||
-] func;
+];
 
 isStruct: [
   var: getVar;
   var.data.getTag VarStruct =
-] func;
+];
 
 isAutoStruct: [
   refToVar:;
   var: refToVar getVar;
   var.data.getTag VarStruct =
   [VarStruct var.data.get.get.hasDestructor copy] &&
-] func;
+];
 
 markAsUnableToDie: [
   refToVar:;
   var: refToVar getVar;
   var.data.getTag VarStruct = [TRUE VarStruct @var.@data.get.get.@unableToDie set] when
-] func;
+];
 
 markAsAbleToDie: [
   refToVar:;
   var: refToVar getVar;
   var.data.getTag VarStruct = [FALSE VarStruct @var.@data.get.get.@unableToDie set] when
-] func;
+];
 
 isSingle: [
   isStruct not
-] func;
+];
 
 isStaticData: [
   refToVar:;
@@ -557,7 +557,7 @@ isStaticData: [
   ] [
     FALSE
   ] if
-] func;
+];
 
 getSingleDataStorageSize: [
   var: getVar;
@@ -583,7 +583,7 @@ getSingleDataStorageSize: [
     ]
     [0nx]
   ) case
-] func;
+];
 
 isNonrecursiveType: [
   refToVar:;
@@ -594,7 +594,7 @@ isNonrecursiveType: [
     [var.data.getTag VarBuiltin =] ||
     [var.data.getTag VarImport =] ||
   ] ||
-] func;
+];
 
 isSemiplainNonrecursiveType: [
   refToVar:;
@@ -604,7 +604,7 @@ isSemiplainNonrecursiveType: [
     [var.data.getTag VarBuiltin =] ||
     [var.data.getTag VarImport =] ||
   ] ||
-] func;
+];
 
 getPlainDataIRType: [
   var: getVar;
@@ -642,7 +642,7 @@ getPlainDataIRType: [
   ) case
 
   @result
-] func;
+];
 
 getPlainDataMPLType: [
   compileOnce
@@ -669,7 +669,7 @@ getPlainDataMPLType: [
   ) case
 
   @result
-] func;
+];
 
 getNonrecursiveDataIRType: [
   compileOnce
@@ -694,7 +694,7 @@ getNonrecursiveDataIRType: [
     ] if
     @result
   ] if
-] func;
+];
 
 getNonrecursiveDataMPLType: [
   compileOnce
@@ -723,14 +723,14 @@ getNonrecursiveDataMPLType: [
     ] if
     @result
   ] if
-] func;
+];
 
 getStructStorageSize: [
   refToVar:;
   var: refToVar getVar;
   struct: VarStruct var.data.get.get;
   struct.structStorageSize copy
-] func;
+];
 
 makeStructStorageSize: [
   refToVar:;
@@ -762,7 +762,7 @@ makeStructStorageSize: [
   @result set
 
   result @struct.@structStorageSize set
-] func;
+];
 
 getStorageSize: [
   refToVar:;
@@ -771,14 +771,14 @@ getStorageSize: [
   ] [
     refToVar getStructStorageSize
   ] if
-] func;
+];
 
 getStructAlignment: [
   refToVar:;
   var: refToVar getVar;
   struct: VarStruct var.data.get.get;
   struct.structAlignment copy
-] func;
+];
 
 makeStructAlignment: [
   refToVar:;
@@ -798,7 +798,7 @@ makeStructAlignment: [
     ] &&
   ] loop
   result @struct.@structAlignment set
-] func;
+];
 
 getAlignment: [
   refToVar:;
@@ -807,13 +807,13 @@ getAlignment: [
   ] [
     refToVar getStructAlignment
   ] if
-] func;
+];
 
 isGlobal: [
   refToVar:;
   var: refToVar getVar;
   var.global copy
-] func;
+];
 
 unglobalize: [
   refToVar:;
@@ -823,13 +823,13 @@ unglobalize: [
     -1 dynamic @var.@globalId set
     refToVar makeVariableIRName
   ] when
-] func;
+];
 
 untemporize: [
   refToVar:;
   var: refToVar getVar;
   FALSE @var.@temporary set
-] func;
+];
 
 fullUntemporize: [
   refToVar:;
@@ -838,13 +838,13 @@ fullUntemporize: [
   var.data.getTag VarStruct = [
     FALSE VarStruct @var.@data.get.get.@forgotten set
   ] when
-] func;
+];
 
 isVirtualRef: [
   refToVar:;
   var: refToVar getVar;
   var.data.getTag VarRef = [var.staticness Virtual =] &&
-] func;
+];
 
 isVirtualType: [
   refToVar:;
@@ -855,7 +855,7 @@ isVirtualType: [
   [var.data.getTag VarCode =] ||
   [var.data.getTag VarStruct = [VarStruct var.data.get.get.fullVirtual copy] &&] ||
   [refToVar isVirtualRef] ||
-] func;
+];
 
 isVirtual: [
   refToVar:;
@@ -863,13 +863,13 @@ isVirtual: [
   var: refToVar getVar;
   var.staticness Virtual =
   [refToVar isVirtualType] ||
-] func;
+];
 
 noMatterToCopy: [
   refToVar:;
   refToVar isVirtual [refToVar isAutoStruct not] &&
   #ref r:; FALSE
-] func;
+];
 
 isVirtualField: [
   refToVar:;
@@ -877,7 +877,7 @@ isVirtualField: [
   var: refToVar getVar;
   var.staticness Virtual =
   [refToVar isVirtualType] ||
-] func;
+];
 
 isForgotten: [
   refToVar:;
@@ -887,7 +887,7 @@ isForgotten: [
   ] [
     FALSE
   ] if
-] func;
+];
 
 getVirtualValue: [
   refToVar:;
@@ -923,7 +923,7 @@ getVirtualValue: [
   ) case
 
   result
-] func;
+];
 
 makeStringId: [
   string:;
@@ -936,7 +936,7 @@ makeStringId: [
     @string move @processor.@nameBuffer.pushBack
     result
   ] if
-] func;
+];
 
 makeTypeAliasId: [
   irTypeName:;
@@ -958,14 +958,14 @@ makeTypeAliasId: [
   ] [
     @irTypeName makeStringId
   ] if
-] func;
+];
 
 getFuncIrType: [
   funcIndex:;
   node: funcIndex processor.nodes.at.get;
   resultId: node.signature toString makeStringId;
   resultId getNameById
-] func;
+];
 
 getFuncMplType: [
   funcIndex:;
@@ -988,7 +988,7 @@ getFuncMplType: [
       ] &&
     ] loop
     "]" @result.cat
-  ] func;
+  ];
 
   "-"                @result.cat
   node.mplConvention @result.cat
@@ -997,7 +997,7 @@ getFuncMplType: [
 
   resultId: @result makeStringId;
   resultId getNameById
-] func;
+];
 
 makeDbgTypeId: [
   refToVar:;
@@ -1009,7 +1009,7 @@ makeDbgTypeId: [
       var.mplTypeId refToVar getTypeDebugDeclaration @processor.@debugInfo.@typeIdToDbgId.insert
     ] when
   ] when
-] func;
+];
 
 bitView: [
   copy f:;
@@ -1031,7 +1031,7 @@ bitView: [
   ] loop
 
   result
-] func;
+];
 
 getPlainConstantIR: [
   var: getVar;
@@ -1068,7 +1068,7 @@ getPlainConstantIR: [
   ] if
 
   result
-] func;
+];
 
 {
   processorResult: ProcessorResult Ref;
@@ -1262,7 +1262,7 @@ cutValue: [
     VarIntX  [value processor.options.pointerSize 32nx = [0i32 cast 0i64 cast][copy] if]
     [@value copy]
   ) case
-] func;
+];
 
 checkValue: [
   copy tag:;
@@ -1279,7 +1279,7 @@ checkValue: [
     [FALSE]
   ) case ["number constant overflow" compilerError] when
   @value
-] func;
+];
 
 zeroValue: [
   copy tag:;
@@ -1311,7 +1311,7 @@ zeroValue: [
       ] if
     ] if
   ] if
-] func;
+];
 
 getStaticStructIR: [
   refToVar:;
@@ -1369,7 +1369,7 @@ getStaticStructIR: [
   result.getTextSize 2 - @result.@chars.shrink
   @result.makeZ
   result
-] func;
+];
 
 # require captures "processor" and "codeNode"
 generateVariableIRNameWith: [
@@ -1383,17 +1383,17 @@ generateVariableIRNameWith: [
     ("%var." hostNode.lastVarName) assembleString makeStringId
     hostNode.lastVarName 1 + @hostNode.@lastVarName set
   ] if
-] func;
+];
 
-generateVariableIRName: [FALSE generateVariableIRNameWith] func;
-generateRegisterIRName: [indexOfNode TRUE generateVariableIRNameWith] func;
+generateVariableIRName: [FALSE generateVariableIRNameWith];
+generateRegisterIRName: [indexOfNode TRUE generateVariableIRNameWith];
 
 makeVariableIRName: [
   refToVar:;
   var: refToVar getVar;
 
   refToVar.hostId refToVar isGlobal not generateVariableIRNameWith @var.@irNameId set
-] func;
+];
 
 findFieldWithOverloadShift: [
   copy overloadShift:;
@@ -1434,6 +1434,6 @@ findFieldWithOverloadShift: [
   ] if
 
   result
-] func;
+];
 
-findField: [0 dynamic findFieldWithOverloadShift] func;
+findField: [0 dynamic findFieldWithOverloadShift];

--- a/variable.mpl
+++ b/variable.mpl
@@ -809,8 +809,8 @@ getFuncMplType: [
     "[" @result.cat
     i: 0;
     [
-      i args.dataSize < [
-        current: i args.at.refToVar;
+      i args.getSize < [
+        current: i args.at;
         current getMplType                                            @result.cat
         i 1 + args.getSize < [
           ","                                                         @result.cat
@@ -823,8 +823,8 @@ getFuncMplType: [
 
   "-"                @result.cat
   node.mplConvention @result.cat
-  node.matchingInfo.inputs catData
-  node.outputs catData
+  node.csignature.inputs catData
+  node.csignature.outputs catData
 
   resultId: @result makeStringId;
   resultId getNameById

--- a/variable.mpl
+++ b/variable.mpl
@@ -740,6 +740,35 @@ getNonrecursiveDataMPLType: [
   ] if
 ];
 
+getNonrecursiveDataDBGType: [
+  compileOnce
+  refToVar:;
+  refToVar isPlain [
+    refToVar getPlainDataMPLType
+  ] [
+    result: String;
+    var: refToVar getVar;
+    var.data.getTag VarString = [
+      "s" toString @result set
+    ] [
+      var.data.getTag VarCode = [
+        "c" toString @result set
+      ] [
+        var.data.getTag VarBuiltin = [
+          "b" toString @result set
+        ] [
+          var.data.getTag VarImport = [
+            ("F" VarImport var.data.get getFuncDbgType) assembleString @result set
+          ] [
+            "Unknown nonrecursive struct" makeStringView compilerError
+          ] if
+        ] if
+      ] if
+    ] if
+    @result
+  ] if
+];
+
 getStructStorageSize: [
   refToVar:;
   var: refToVar getVar;
@@ -1020,6 +1049,38 @@ getFuncMplType: [
   resultId getNameById
 ];
 
+getFuncDbgType: [
+ Index:;
+  result: String;
+  node:Index processor.nodes.at.get;
+
+  catData: [
+    args:;
+
+    "[" @result.cat
+    i: 0;
+    [
+      i args.getSize < [
+        current: i args.at;
+        current getDbgType                                            @result.cat
+        i 1 + args.getSize < [
+          ","                                                         @result.cat
+        ] when
+        i 1 + @i set TRUE
+      ] &&
+    ] loop
+    "]" @result.cat
+  ];
+
+  "-"                @result.cat
+  node.mplConvention @result.cat
+  node.csignature.inputs catData
+  node.csignature.outputs catData
+
+  resultId: @result makeStringId;
+  resultId getNameById
+];
+
 makeDbgTypeId: [
   refToVar:;
   refToVar isVirtualType not [
@@ -1129,7 +1190,7 @@ getPlainConstantIR: [
   refToVar isNonrecursiveType [
     refToVar getNonrecursiveDataIRType  @resultIR set
     refToVar getNonrecursiveDataMPLType @resultMPL set
-    refToVar getNonrecursiveDataMPLType @resultDBG set
+    refToVar getNonrecursiveDataDBGType @resultDBG set
   ] [
     var.data.getTag VarRef = [
       branch: VarRef var.data.get;

--- a/variable.mpl
+++ b/variable.mpl
@@ -4,8 +4,9 @@
 "Variant"   includeModule
 "Owner"     includeModule
 
-"irWriter" includeModule
+"irWriter"    includeModule
 "debugWriter" includeModule
+"processor"   includeModule
 
 Dirty:           [0n8 dynamic] func;
 Dynamic:         [1n8 dynamic] func;
@@ -163,6 +164,168 @@ Variable: [{
   INIT: [];
   DIE: [];
 }] func;
+
+compilable: [processorResult.success copy] func;
+
+{
+  signature: CFunctionSignature Cref;
+  compilerPositionInfo: CompilerPositionInfo Cref;
+  multiParserResult: MultiParserResult Cref;
+  indexArray: IndexArray Cref;
+  processor: Processor Ref;
+  processorResult: ProcessorResult Ref;
+  nodeCase: NodeCaseCode;
+  parentIndex: 0;
+  functionName: StringView Cref;
+} 0 {convention: cdecl;} "astNodeToCodeNode" importFunction
+
+{
+  signature: CFunctionSignature Cref;
+  compilerPositionInfo: CompilerPositionInfo Cref;
+  multiParserResult: MultiParserResult Cref;
+  processor: Processor Ref;
+  processorResult: ProcessorResult Ref;
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} "createDtorForGlobalVar" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  positionInfo: CompilerPositionInfo Cref;
+  name: StringView Cref;
+  nodeCase: NodeCaseCode;
+  indexArray: IndexArray Cref;
+} () {convention: cdecl;} "processCallByIndexArrayImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  index: Int32;
+} () {convention: cdecl;} "callBuiltinImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} "processFuncPtrImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  preAstNodeIndex: Int32;
+} Cond {convention: cdecl;} "processPreImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  name: StringView Cref;
+  callAstNodeIndex: Int32;
+} () {convention: cdecl;} "processCallImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  asLambda: Cond;
+  name: StringView Cref;
+  astNode: AstNode Cref;
+  signature: CFunctionSignature Cref;
+} Int32 {convention: cdecl;} "processExportFunctionImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  asCodeRef: Cond;
+  name: StringView Cref;
+  signature: CFunctionSignature Cref;
+} Int32 {convention: cdecl;} "processImportFunctionImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+
+  comparingMessage: String Ref;
+  curToNested: RefToVarTable Ref;
+  nestedToCur: RefToVarTable Ref;
+  currentMatchingNodeIndex: Int32;
+  cacheEntry: RefToVar Cref;
+  stackEntry: RefToVar Cref;
+} Cond {convention: cdecl;} "compareEntriesRecImpl" importFunction
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} "makeVariableTypeImpl" importFunction
+
+{
+  forMatching: Cond;
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  result: RefToVar Ref;
+} () {convention: cdecl;} "popImpl" importFunction
+
+{
+  dynamicStoraged: Cond;
+
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+
+  reason: Nat8;
+  end: RefToVar Ref;
+  begin: RefToVar Ref;
+  refToVar: RefToVar Cref;
+} () {convention: cdecl;} "makeShadowsImpl" importFunction
+
+makeVariableType: [
+  multiParserResult @currentNode indexOfNode @processor @processorResult makeVariableTypeImpl
+] func;
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  message: StringView Cref;
+} () {convention: cdecl;} "compilerErrorImpl" importFunction
+
+compilerError: [
+  makeStringView multiParserResult @currentNode indexOfNode @processor @processorResult compilerErrorImpl
+] func;
+
 
 # these functions require capture "processor"
 variableIsDeleted: [
@@ -482,6 +645,7 @@ getPlainDataIRType: [
 ] func;
 
 getPlainDataMPLType: [
+  compileOnce
   var: getVar;
   result: String;
   var.data.getTag (
@@ -508,6 +672,7 @@ getPlainDataMPLType: [
 ] func;
 
 getNonrecursiveDataIRType: [
+  compileOnce
   refToVar:;
   refToVar isPlain [
     refToVar getPlainDataIRType
@@ -532,6 +697,7 @@ getNonrecursiveDataIRType: [
 ] func;
 
 getNonrecursiveDataMPLType: [
+  compileOnce
   refToVar:;
   refToVar isPlain [
     refToVar getPlainDataMPLType
@@ -845,7 +1011,79 @@ makeDbgTypeId: [
   ] when
 ] func;
 
-makeVariableType: [
+bitView: [
+  copy f:;
+  buffer: f storageAddress (0n8 0n8 0n8 0n8 0n8 0n8 0n8 0n8) addressToReference;
+  result: String;
+  "0x" @result.cat
+  hexToStr: (
+    "0" makeStringView "1" makeStringView "2" makeStringView "3" makeStringView "4" makeStringView
+    "5" makeStringView "6" makeStringView "7" makeStringView "8" makeStringView "9" makeStringView
+    "A" makeStringView "B" makeStringView "C" makeStringView "D" makeStringView "E" makeStringView "F" makeStringView);
+  i: 0 dynamic;
+  [
+    i 0ix cast 0nx cast f storageSize < [
+      d: f storageSize 0ix cast 0 cast i - 1 - buffer @ 0n32 cast;
+      d 4n32 rshift 0 cast @hexToStr @ @result.cat
+      d 15n32 and 0 cast @hexToStr @ @result.cat
+      i 1 + @i set TRUE
+    ] &&
+  ] loop
+
+  result
+] func;
+
+getPlainConstantIR: [
+  var: getVar;
+  result: String;
+  var.data.getTag VarCond = [
+    VarCond var.data.get ["true" toString] ["false" toString] if @result set
+  ] [
+    var.data.getTag VarInt8 = [VarInt8 var.data.get toString @result set] [
+      var.data.getTag VarInt16 = [VarInt16 var.data.get toString @result set] [
+        var.data.getTag VarInt32 = [VarInt32 var.data.get toString @result set] [
+          var.data.getTag VarInt64 = [VarInt64 var.data.get toString @result set] [
+            var.data.getTag VarIntX = [VarIntX var.data.get toString @result set] [
+              var.data.getTag VarNat8 = [VarNat8 var.data.get toString @result set] [
+                var.data.getTag VarNat16 = [VarNat16 var.data.get toString @result set] [
+                  var.data.getTag VarNat32 = [VarNat32 var.data.get toString @result set] [
+                    var.data.getTag VarNat64 = [VarNat64 var.data.get toString @result set] [
+                      var.data.getTag VarNatX = [VarNatX var.data.get toString @result set] [
+                        var.data.getTag VarReal32 = [VarReal32 var.data.get 0.0r32 cast 0.0r64 cast bitView @result set] [
+                          var.data.getTag VarReal64 = [VarReal64 var.data.get bitView @result set] [
+                            ("Tag = " makeStringView var.data.getTag 0 cast) addLog
+                            [FALSE] "Unknown plain struct while getting IR value" assert
+                          ] if
+                        ] if
+                      ] if
+                    ] if
+                  ] if
+                ] if
+              ] if
+            ] if
+          ] if
+        ] if
+      ] if
+    ] if
+  ] if
+
+  result
+] func;
+
+{
+  processorResult: ProcessorResult Ref;
+  processor: Processor Ref;
+  indexOfNode: Int32;
+  currentNode: CodeNode Ref;
+  multiParserResult: MultiParserResult Cref;
+  refToVar: RefToVar Cref;
+} () {} [
+  processorResult:;
+  processor:;
+  copy indexOfNode:;
+  currentNode:;
+  multiParserResult:;
+  failProc: @failProcForProcessor;
   refToVar:;
 
   #fill info:
@@ -868,7 +1106,7 @@ makeVariableType: [
   resultDBG: String;
 
   refToVar isNonrecursiveType [
-    refToVar getNonrecursiveDataIRType @resultIR set
+    refToVar getNonrecursiveDataIRType  @resultIR set
     refToVar getNonrecursiveDataMPLType @resultMPL set
     refToVar getNonrecursiveDataMPLType @resultDBG set
   ] [
@@ -1008,29 +1246,7 @@ makeVariableType: [
   @resultDBG makeStringId @var.@dbgTypeId set
   @resultMPL makeStringId @var.@mplTypeId set
   processor.options.debug [refToVar makeDbgTypeId] when
-] func;
-
-bitView: [
-  copy f:;
-  buffer: f storageAddress (0n8 0n8 0n8 0n8 0n8 0n8 0n8 0n8) addressToReference;
-  result: String;
-  "0x" @result.cat
-  hexToStr: (
-    "0" makeStringView "1" makeStringView "2" makeStringView "3" makeStringView "4" makeStringView
-    "5" makeStringView "6" makeStringView "7" makeStringView "8" makeStringView "9" makeStringView
-    "A" makeStringView "B" makeStringView "C" makeStringView "D" makeStringView "E" makeStringView "F" makeStringView);
-  i: 0 dynamic;
-  [
-    i 0ix cast 0nx cast f storageSize < [
-      d: f storageSize 0ix cast 0 cast i - 1 - buffer @ 0n32 cast;
-      d 4n32 rshift 0 cast @hexToStr @ @result.cat
-      d 15n32 and 0 cast @hexToStr @ @result.cat
-      i 1 + @i set TRUE
-    ] &&
-  ] loop
-
-  result
-] func;
+] "makeVariableTypeImpl" exportFunction
 
 cutValue: [
   copy tag:;
@@ -1152,43 +1368,6 @@ getStaticStructIR: [
 
   result.getTextSize 2 - @result.@chars.shrink
   @result.makeZ
-  result
-] func;
-
-getPlainConstantIR: [
-  var: getVar;
-  result: String;
-  var.data.getTag VarCond = [
-    VarCond var.data.get ["true" toString] ["false" toString] if @result set
-  ] [
-    var.data.getTag VarInt8 = [VarInt8 var.data.get toString @result set] [
-      var.data.getTag VarInt16 = [VarInt16 var.data.get toString @result set] [
-        var.data.getTag VarInt32 = [VarInt32 var.data.get toString @result set] [
-          var.data.getTag VarInt64 = [VarInt64 var.data.get toString @result set] [
-            var.data.getTag VarIntX = [VarIntX var.data.get toString @result set] [
-              var.data.getTag VarNat8 = [VarNat8 var.data.get toString @result set] [
-                var.data.getTag VarNat16 = [VarNat16 var.data.get toString @result set] [
-                  var.data.getTag VarNat32 = [VarNat32 var.data.get toString @result set] [
-                    var.data.getTag VarNat64 = [VarNat64 var.data.get toString @result set] [
-                      var.data.getTag VarNatX = [VarNatX var.data.get toString @result set] [
-                        var.data.getTag VarReal32 = [VarReal32 var.data.get 0.0r32 cast 0.0r64 cast bitView @result set] [
-                          var.data.getTag VarReal64 = [VarReal64 var.data.get bitView @result set] [
-                            ("Tag = " makeStringView var.data.getTag 0 cast) addLog
-                            [FALSE] "Unknown plain struct while getting IR value" assert
-                          ] if
-                        ] if
-                      ] if
-                    ] if
-                  ] if
-                ] if
-              ] if
-            ] if
-          ] if
-        ] if
-      ] if
-    ] if
-  ] if
-
   result
 ] func;
 

--- a/variable.mpl
+++ b/variable.mpl
@@ -922,8 +922,14 @@ getVirtualValue: [
       "}" @result.cat
     ]
 
-    VarString  [VarString var.data.get makeStringView getStringImplementation @result set]
-    VarCode    [VarCode    var.data.get.index @result.cat]
+    VarString  [
+      string: VarString var.data.get;
+      (string textSize "_" string getStringImplementation) @result.catMany
+    ]
+    VarCode    [
+      info: VarCode    var.data.get;
+      ("\"" info.moduleId processor.options.fileNames.at getStringImplementation "\"/" info.line ":" info.column) @result.catMany
+    ]
     VarImport  [VarImport  var.data.get @result.cat]
     VarBuiltin [VarBuiltin var.data.get @result.cat]
     VarRef     ["."                     @result.cat]

--- a/variable.mpl
+++ b/variable.mpl
@@ -453,7 +453,6 @@ refsAreEqual: [
 variablesAreSame: [
   refToVar1:;
   refToVar2:;
-  #refToVar1 getVar.mplType makeStringView refToVar2 getVar.mplType makeStringView stringCompare
   refToVar1 getVar.mplTypeId refToVar2 getVar.mplTypeId = # id compare better than string compare!
 ];
 
@@ -895,7 +894,6 @@ isVirtualType: [
 
   var: refToVar getVar;
   var.data.getTag VarBuiltin =
-  #[var.data.getTag VarImport =] ||
   [var.data.getTag VarCode =] ||
   [var.data.getTag VarStruct = [VarStruct var.data.get.get.fullVirtual copy] &&] ||
   [refToVar isVirtualRef] ||
@@ -912,7 +910,6 @@ isVirtual: [
 noMatterToCopy: [
   refToVar:;
   refToVar isVirtual [refToVar isAutoStruct not] &&
-  #ref r:; FALSE
 ];
 
 isVirtualField: [

--- a/variable.mpl
+++ b/variable.mpl
@@ -52,6 +52,10 @@ hash: ["REF_TO_VAR" has] [
   refToVar.hostId 0n32 cast 67n32 * refToVar.varId 0n32 cast 17n32 * +
 ] pfunc;
 
+=: ["CODE_NODE_INFO" has] [
+  l:r:;;
+  l.index r.index =
+] pfunc;
 NameInfoEntry: [{
   refToVar: RefToVar;
   startPoint: -1 dynamic; # id of node
@@ -111,6 +115,16 @@ Struct: [{
   structAlignment: 0nx dynamic;
 }]; #IDs of pointee vars
 
+CodeNodeInfo: [{
+  CODE_NODE_INFO: ();
+
+  moduleId: Int32;
+  offset: Int32;
+  line: Int32;
+  column: Int32;
+  index: Int32;
+}];
+
 Variable: [{
   VARIABLE: ();
 
@@ -153,7 +167,7 @@ Variable: [{
     Int64            #VarIntX
     Real64           #VarReal32
     Real64           #VarReal64
-    Int32            #VarCode; id of node
+    CodeNodeInfo     #VarCode; id of node
     Int32            #VarBuiltin
     Int32            #VarImport
     String           #VarString
@@ -909,7 +923,7 @@ getVirtualValue: [
     ]
 
     VarString  [VarString var.data.get makeStringView getStringImplementation @result set]
-    VarCode    [VarCode    var.data.get @result.cat]
+    VarCode    [VarCode    var.data.get.index @result.cat]
     VarImport  [VarImport  var.data.get @result.cat]
     VarBuiltin [VarBuiltin var.data.get @result.cat]
     VarRef     ["."                     @result.cat]

--- a/variable.mpl
+++ b/variable.mpl
@@ -110,7 +110,6 @@ Struct: [{
   forgotten:     TRUE  dynamic;
   realFieldIndexes: Int32 Array;
   fields: FieldArray;
-  structName: NameWithOverload; # for overloads
   structStorageSize: 0nx dynamic;
   structAlignment: 0nx dynamic;
 }]; #IDs of pointee vars

--- a/variable.mpl
+++ b/variable.mpl
@@ -167,6 +167,16 @@ Variable: [{
 
 compilable: [processorResult.success copy];
 
+callBuiltin:           [multiParserResult @currentNode indexOfNode @processor @processorResult callBuiltinImpl];
+processFuncPtr:        [multiParserResult @currentNode indexOfNode @processor @processorResult processFuncPtrImpl];
+processPre:            [multiParserResult @currentNode indexOfNode @processor @processorResult processPreImpl];
+processCall:           [multiParserResult @currentNode indexOfNode @processor @processorResult processCallImpl];
+processExportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processExportFunctionImpl];
+processImportFunction: [multiParserResult @currentNode indexOfNode @processor @processorResult processImportFunctionImpl];
+compareEntriesRec:     [currentMatchingNodeIndex @nestedToCur @curToNested @comparingMessage multiParserResult @currentNode indexOfNode @processor @processorResult compareEntriesRecImpl];
+makeVariableType:      [multiParserResult @currentNode indexOfNode @processor @processorResult makeVariableTypeImpl];
+compilerError:         [makeStringView multiParserResult @currentNode indexOfNode @processor @processorResult compilerErrorImpl];
+
 {
   signature: CFunctionSignature Cref;
   compilerPositionInfo: CompilerPositionInfo Cref;
@@ -309,10 +319,6 @@ compilable: [processorResult.success copy];
   refToVar: RefToVar Cref;
 } () {convention: cdecl;} "makeShadowsImpl" importFunction
 
-makeVariableType: [
-  multiParserResult @currentNode indexOfNode @processor @processorResult makeVariableTypeImpl
-];
-
 {
   processorResult: ProcessorResult Ref;
   processor: Processor Ref;
@@ -321,11 +327,6 @@ makeVariableType: [
   multiParserResult: MultiParserResult Cref;
   message: StringView Cref;
 } () {convention: cdecl;} "compilerErrorImpl" importFunction
-
-compilerError: [
-  makeStringView multiParserResult @currentNode indexOfNode @processor @processorResult compilerErrorImpl
-];
-
 
 # these functions require capture "processor"
 variableIsDeleted: [

--- a/variable.mpl
+++ b/variable.mpl
@@ -4,6 +4,9 @@
 "Variant"   includeModule
 "Owner"     includeModule
 
+"irWriter" includeModule
+"debugWriter" includeModule
+
 Dirty:           [0n8 dynamic] func;
 Dynamic:         [1n8 dynamic] func;
 Weak:            [2n8 dynamic] func;

--- a/variable.mpl
+++ b/variable.mpl
@@ -138,6 +138,7 @@ Variable: [{
   temporary: TRUE dynamic;
   usedInHeader: FALSE dynamic;
   capturedAsMutable: FALSE dynamic;
+  capturedAsRealValue: FALSE dynamic;
   tref: TRUE dynamic;
   shadowReason: ShadowReasonNo;
   globalId: -1 dynamic;


### PR DESCRIPTION
## Language changes
* ### Calling conventions support
  An options object in function signatures can now specify a calling convention. The compiler passes conventions directly to LLVM IR without any checks. There are functions `cdecl` and `stdcall` in `mpl-sl/conventions.mpl` that return string constants for corresponding conventions. The list of supported calling conventions is available in [LLVM documentation](https://llvm.org/docs/LangRef.html#calling-conventions).
  #### Example:
  ```
  {} {} {convention: "ccc";} "test" importFunction
  ```
* ### Unified syntax for callables
  If a name that captured a [code] used without `@`, the content would be called, same as with other callables.

* ### Removed built-in functions `new`, `delete`
  Use functions `new`, `delete` from `mpl-sl/memory.mpl` instead.

## Compiler changes
* ### Global static data storage
  The compiler places global static arrays in a global LLVM IR variable and initialises them in-place. 
* ### Independent compilation of exported functions
  Previously, the compiler could report only one error per compilation. Errors from functions that have a user-defined signature do not stop a compilation now.
  #### Example:
   test.mpl:
   ```
   {} {} {convention: "ccc";} [
     test2: {} {} {convention: "ccc";} codeRef;
     [123] !test2
     [x:;] !test2
     [] !test2
     test2
   ] "test1" exportFunction

  {} {} {convention: "ccc";} [1 "" +] "test3" exportFunction
  ```
  command line:
  ```
  mplc.exe -o test.ll test.mpl
  ```
  output:
  ```
  test.mpl(3,10): error, [!test2], signature is void, export function must be without output
  test.mpl(7,11): [exportFunction], called from here
  
  test.mpl(4,5): error, [x:], stack underflow
  test.mpl(4,10): [!test2], called from here
  test.mpl(7,11): [exportFunction], called from here
  
  test.mpl(9,34): error, [+], second argument invalid
  test.mpl(9,45): [exportFunction], called from here
  ```
* ### Error report improvements:
  * added name and type of capture to the error message about a local capture in non-virtual function
  * fixed error messages about local exportFunction\exportVariable
  * added filename, line and column to the printed schema of a [code]
* ### Bug fixes:
  * limited PRE recursion depth
  * dynamised all variable-dependent entities if a reference to that variable put in a dynamic context
  * fixed order of writes to the type names in the debug info
  * fixed IR for calls of variadic functions with no arguments
  * fixed crash when a code assigned to a reference to a variadic function
  * fixed crash when used-defined names "closure" and "self" shadow compiler-defined names
  * started to use PRE captures in matching
  * removed confusing compilation error when dynamic codeRef created inside the dynamic loop
  * fixed order of the dereferences of function outputs
  * removed confusing compilation error when virtual variable wrapped into a built-in list
  * made distinguishable function signatures with the same arguments type but different levels of indirection 
  * suppressed errors from PRE when one of the previous errors is recursion depth limit exceeding
  * fixed that built-in `textSplit` would have no return value when the input is an empty string
  * fixed that parser would recognize 0x as a valid token
  * added possibility to cast a number to a schema of a number 
  * prohibited virtual codeRef's
  * fixed IR for non-virtual usages of virtual strings
  * fixed crash when built-in function dynamic applied to a schema
  * made parser correctly recognize names consisting of dots
  * made compiler correctly process local overloads
  * fixed IR for codeRefs in failed PRE
  * limited number of unwrapped calls in one node
  * dynamized global variables
  * made non-virtual functions implicitly touch the last input whenever it was not touched