### PR TITLE
Incremental update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a self-hosted MPL compiler.
 ## Building
 
 Because the MPL Compiler is self-hosted, you cannot build it without MPL Compiler.
-To help with bootstrapping, we provide precompiled `mplc.ll` files, see releases.
+To help with bootstrapping, we provide precompiled `mplc.ll` files, see [releases](https://github.com/Matway/mpl-c/releases).
 
 ### Prerequisites
 

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -273,8 +273,7 @@ mplNumberUnaryOp: [
 ] "mplBuiltinFalse" @declareBuiltin ucall
 
 [
-  s: LF toString;
-  s VarString createVariable createStringIR push
+  LF toString makeVarString push
 ] "mplBuiltinLF" @declareBuiltin ucall
 
 [
@@ -522,7 +521,7 @@ mplShiftBinaryOp: [
   refToVar: pop;
   compilable [
     refToVar getVar.data.getTag VarRef = [
-      refToVar isVirtualRef [
+      refToVar isSchema [
         "can not deref virtual-reference" makeStringView compilerError
       ] [
         refToVar getPointee push
@@ -594,7 +593,7 @@ mplBuiltinProcessAtList: [
     structVar: refToStruct getVar;
     indexVar: refToIndex getVar;
 
-    refToStruct isVirtualRef [
+    refToStruct isSchema [
 
       (
         [compilable]
@@ -611,7 +610,7 @@ mplBuiltinProcessAtList: [
           index 0 < [index struct.fields.getSize < not] || ["index is out of bounds" compilerError] when
         ] [
           field: index struct.fields.at.refToVar;
-          field VarRef TRUE dynamic TRUE dynamic createVariableWithVirtual @result set
+          field VarRef TRUE dynamic TRUE dynamic TRUE dynamic createVariableWithVirtual @result set
           refToStruct.mutable @result.@mutable set
           result fullUntemporize
         ]
@@ -630,7 +629,7 @@ mplBuiltinProcessAtList: [
                 realRefToStruct: refToStruct;
                 realStructVar: structVar;
                 realStruct: struct;
-                refToStruct staticnessOfVar Virtual = [
+                refToStruct staticnessOfVar Virtual < not [
                   "can't get dynamic index in virtual struct" compilerError
                 ] when
 
@@ -646,7 +645,7 @@ mplBuiltinProcessAtList: [
 
                 refToStruct.mutable @fieldRef.@mutable set
                 fieldRef fullUntemporize
-                fieldRef staticnessOfVar Virtual = [
+                fieldRef staticnessOfVar Virtual < not [
                   "dynamic index is combined of virtuals" compilerError
                 ] [
                   fieldRef makeVarTreeDynamicStoraged
@@ -812,11 +811,17 @@ parseSignature: [
             ) sequence
           ]
           processor.conventionNameInfo [
-            conventionRefToVar: f.refToVar;
-            conventionVar: conventionRefToVar getVar;
+            conventionRefToVarRef: f.refToVar;
+            conventionVarRef: conventionRefToVarRef getVar;
             (
               [compilable]
-              [conventionVar.data.getTag VarString = not ["value must be String" compilerError] when]
+              [conventionVarRef.data.getTag VarRef = not ["value must be String Ref" compilerError] when]
+              [conventionRefToVarRef staticnessOfVar Weak < ["value must be Static" compilerError] when]
+              [
+                conventionRefToVar: VarRef conventionVarRef.data.get;
+                conventionVar: conventionRefToVar getVar;
+                conventionVar.data.getTag VarString = not ["value must be String Ref" compilerError] when
+              ]
               [conventionRefToVar staticnessOfVar Weak < ["value must be Static" compilerError] when]
               [
                 string: VarString conventionVar.data.get;
@@ -846,7 +851,7 @@ parseSignature: [
           returnVar.temporary [
             return @result.@outputs.pushBack
           ] [
-            return return.mutable createRef @result.@outputs.pushBack
+            return TRUE dynamic createRef @result.@outputs.pushBack
           ] if
         ] if
       ] when
@@ -896,7 +901,7 @@ parseSignature: [
       refToVar isVirtual ["cannot export virtual var" compilerError] when
     ] [
       refToVar getVar.temporary not [
-        refToVar refToVar.mutable createRef @refToVar set
+        refToVar TRUE dynamic createRef @refToVar set
       ] when
       var: refToVar getVar;
       FALSE @var.@temporary set
@@ -976,7 +981,7 @@ parseSignature: [
             "variable cant be virtual" compilerError
           ] [
             varType.temporary not [
-              refToType refToType.mutable createRef @refToType set
+              refToType TRUE dynamic createRef @refToType set
             ] when
 
             name: VarString varName.data.get;
@@ -1014,15 +1019,19 @@ parseSignature: [
       refToVar getVar.data.getTag VarImport = [
         "functions cannot be copied" compilerError
       ] [
-        result: refToVar copyVarToNew;
-        result isVirtual [
-          result isAutoStruct ["unable to copy virtual autostruct" compilerError] when
+        refToVar getVar.data.getTag VarString = [
+          "builtin-strings cannot be copied" compilerError
         ] [
-          TRUE @result.@mutable set
-          refToVar result createCopyToNew
-        ] if
+          result: refToVar copyVarToNew;
+          result isVirtual [
+            result isAutoStruct ["unable to copy virtual autostruct" compilerError] when
+          ] [
+            TRUE @result.@mutable set
+            refToVar result createCopyToNew
+          ] if
 
-        result push
+          result push
+        ] if
       ] if
     ] if
   ] when
@@ -1032,7 +1041,7 @@ parseSignature: [
   refToVar: pop;
   compilable [
     result: refToVar copyVarToNew;
-    result isVirtual not [
+    result isVirtual not [result isUnallocable not] && [
       TRUE @result.@mutable set
       result createAllocIR callInit
     ] when
@@ -1151,11 +1160,7 @@ parseSignature: [
       refToDst: 0n64 VarNatX createVariable;
       Dynamic @refToDst getVar.@staticness set
       var: refToVar getVar;
-      var.data.getTag VarString = [
-        refToVar refToDst "ptrtoint" makeStringView createCastCopyToNew
-      ] [
-        refToVar refToDst "ptrtoint" makeStringView createCastCopyPtrToNew
-      ] if
+      refToVar refToDst "ptrtoint" makeStringView createCastCopyPtrToNew
       refToDst push
     ]
   ) sequence
@@ -1171,40 +1176,25 @@ parseSignature: [
     var.data.getTag VarNatX = [
       var: refToVar getVar;
       varSchema: refToSchema getVar;
-      varSchema.data.getTag VarString = [
-        refToDst: String VarString createVariable;
-        Dirty @refToDst getVar.@staticness set
-
-        refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
-        refToDst push
-      ] [
-        varSchema.data.getTag VarImport = [
-          refToDst: refToSchema VarRef createVariable;
-          Dynamic @refToDst getVar.@staticness set
-          refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
-          refToDst derefAndPush
+      schemaOfResult: RefToVar;
+      varSchema.data.getTag VarRef = [
+        refToSchema isSchema [
+          VarRef varSchema.data.get copyVarFromChild @schemaOfResult set
+          refToSchema.mutable schemaOfResult.mutable and @schemaOfResult.@mutable set
         ] [
-          schemaOfResult: RefToVar;
-          varSchema.data.getTag VarRef = [
-            refToSchema isVirtual [
-              VarRef varSchema.data.get copyVarFromChild @schemaOfResult set
-              refToSchema.mutable schemaOfResult.mutable and @schemaOfResult.@mutable set
-            ] [
-              [FALSE] "Unable in current semantic!" assert
-            ] if
-          ] [
-            refToSchema @schemaOfResult set
-          ] if
-
-          schemaOfResult isVirtual [
-            "pointee is virtual, cannot cast" compilerError
-          ] [
-            refToDst: schemaOfResult VarRef createVariable;
-            Dirty refToDst getVar.@staticness set
-            refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
-            refToDst getPointee derefAndPush
-          ] if
+          [FALSE] "Unable in current semantic!" assert
         ] if
+      ] [
+        refToSchema @schemaOfResult set
+      ] if
+
+      schemaOfResult isVirtual [
+        "pointee is virtual, cannot cast" compilerError
+      ] [
+        refToDst: schemaOfResult VarRef createVariable;
+        Dirty refToDst getVar.@staticness set
+        refToVar refToDst "inttoptr" makeStringView createCastCopyToNew
+        refToDst derefAndPush
       ] if
     ] [
       "address must be a NatX" compilerError
@@ -1298,7 +1288,7 @@ parseSignature: [
       varStr1: refToStr1 getVar;
       varStr1.data.getTag VarString = not ["must be static string" compilerError] when
     ]
-    [(VarString varStr1.data.get VarString varStr2.data.get) assembleString VarString createVariable createStringIR push]
+    [(VarString varStr1.data.get VarString varStr2.data.get) assembleString makeVarString push]
   ) sequence
 ] "mplBuiltinStrCat" @declareBuiltin ucall
 
@@ -1313,18 +1303,15 @@ parseSignature: [
         string: VarString varName.data.get;
         struct: Struct;
 
-        fields: RefToVar Array;
-
         string.chars.dataSize 0 < not [
           splitted: string makeStringView.split;
           splitted.success [
             splitted.chars [
               pair:;
-              element: pair.value toString VarString createVariable;
-              element @fields.pushBack
+              element: pair.value toString makeVarString;
               field: Field;
               processor.emptyNameInfo @field.@nameInfo set
-              element @field.@refToVar set
+              element TRUE dynamic createRef @field.@refToVar set
               field @struct.@fields.pushBack
             ] each
 
@@ -1337,17 +1324,17 @@ parseSignature: [
               i resultStruct.fields.dataSize < [
                 field: i resultStruct.fields.at;
 
-                refToName isGlobal [
+                result isGlobal [
                   currentNode.program.dataSize field.refToVar getVar.@allocationInstructionIndex set
                   "no alloc..." makeStringView createComent # fake instruction
 
-                  loadReg: field.refToVar createStringIR createDerefToRegister;
+                  loadReg: field.refToVar createDerefToRegister;
                   field.refToVar unglobalize
                   loadReg field.refToVar createStoreFromRegister
 
                   field.refToVar i result createGEPInsteadOfAlloc
                 ] [
-                  field.refToVar createStringIR i result createGEPInsteadOfAlloc
+                  field.refToVar i result createGEPInsteadOfAlloc
                 ] if
                 i 1 + @i set TRUE
               ] &&
@@ -1435,7 +1422,7 @@ parseSignature: [
   refToVar: pop;
   compilable [
     refToVar isVirtual [
-      refToVar isVirtualRef [
+      refToVar isSchema [
         pointee: VarRef refToVar getVar.data.get;
         pointee isVirtual [
           0nx
@@ -1457,7 +1444,7 @@ parseSignature: [
   refToVar: pop;
   compilable [
     refToVar isVirtual [
-      refToVar isVirtualRef [
+      refToVar isSchema [
         pointee: VarRef refToVar getVar.data.get;
         pointee isVirtual [
           0nx
@@ -1567,7 +1554,7 @@ parseSignature: [
   refToVar: pop;
   compilable [
     var: refToVar getVar;
-    refToVar isVirtualRef [
+    refToVar isSchema [
       pointee: VarRef var.data.get;
       pointeeVar: pointee getVar;
       pointeeVar.data.getTag VarStruct = not ["not a combined" makeStringView compilerError] when
@@ -1588,18 +1575,18 @@ parseSignature: [
   refToVar: pop;
   compilable [
     varCount: refToCount getVar;
-    varCount.data.getTag VarInt32 = not ["count must be Int32" compilerError] when
+    varCount.data.getTag VarInt32 = not ["index must be Int32" compilerError] when
     compilable [
-      refToCount staticnessOfVar Dynamic > not ["count must be static" compilerError] when
+      refToCount staticnessOfVar Dynamic > not ["index must be static" compilerError] when
       compilable [
         count: VarInt32 varCount.data.get 0 cast;
         var: refToVar getVar;
-        refToVar isVirtualRef [
+        refToVar isSchema [
           pointee: VarRef var.data.get;
           pointeeVar: pointee getVar;
           pointeeVar.data.getTag VarStruct = not ["not a combined" compilerError] when
           compilable [
-            count VarStruct pointeeVar.data.get.get.fields.at.nameInfo processor.nameInfos.at.name VarString createVariable createStringIR push
+            count VarStruct pointeeVar.data.get.get.fields.at.nameInfo processor.nameInfos.at.name makeVarString push
           ] when
         ] [
           var.data.getTag VarStruct = not ["not a combined" compilerError] when
@@ -1607,7 +1594,7 @@ parseSignature: [
             struct: VarStruct var.data.get.get;
             count 0 < [count struct.fields.getSize < not] || ["index is out of bounds" compilerError] when
             compilable [
-              count struct.fields.at.nameInfo processor.nameInfos.at.name VarString createVariable createStringIR push
+              count struct.fields.at.nameInfo processor.nameInfos.at.name makeVarString push
             ] when
           ] when
         ] if
@@ -1682,6 +1669,60 @@ parseSignature: [
     ] when
   ] when
 ] "mplBuiltinArray" @declareBuiltin ucall
+
+[
+  varPrev:   0n64 VarNatX createVariable;
+  varNext:   0n64 VarNatX createVariable;
+  varName:   String makeVarString TRUE dynamic createRefNoOp;
+  varLine:   0i64 VarInt32 createVariable;
+  varColumn: 0i64 VarInt32 createVariable;
+
+  varPrev   makeVarDirty
+  varNext   makeVarDirty
+  varName   makeVarDirty
+  varLine   makeVarDirty
+  varColumn makeVarDirty
+
+  struct: Struct;
+  5 @struct.@fields.resize
+
+  varPrev             0 @struct.@fields.at.@refToVar set
+  "prev" findNameInfo 0 @struct.@fields.at.@nameInfo set
+
+  varNext             1 @struct.@fields.at.@refToVar set
+  "next" findNameInfo 1 @struct.@fields.at.@nameInfo set
+
+  varName             2 @struct.@fields.at.@refToVar set
+  "name" findNameInfo 2 @struct.@fields.at.@nameInfo set
+
+  varLine             3 @struct.@fields.at.@refToVar set
+  "line" findNameInfo 3 @struct.@fields.at.@nameInfo set
+  
+  varColumn             4 @struct.@fields.at.@refToVar set
+  "column" findNameInfo 4 @struct.@fields.at.@nameInfo set
+
+  first: @struct move owner VarStruct createVariable;
+  last: first copyVar;
+
+  firstRef: first FALSE dynamic createRefNoOp;
+  lastRef:  last  FALSE dynamic createRefNoOp;
+
+  firstRef makeVarDirty
+  lastRef  makeVarDirty
+
+  resultStruct: Struct;
+  2 @resultStruct.@fields.resize
+
+  firstRef             0 @resultStruct.@fields.at.@refToVar set
+  "first" findNameInfo 0 @resultStruct.@fields.at.@nameInfo set
+
+  lastRef             1 @resultStruct.@fields.at.@refToVar set
+  "last" findNameInfo 1 @resultStruct.@fields.at.@nameInfo set
+
+  result: @resultStruct move owner VarStruct createVariable createAllocIR;
+  first getIrType result getIrType result createGetCallTrace
+  result push
+] "mplBuiltinGetCallTrace" @declareBuiltin ucall
 
 [
   refToVar: pop;

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -41,6 +41,7 @@ builtins: (
   {name: "fieldIndex"              ; impl: @mplBuiltinFieldIndex              ;}
   {name: "fieldName"               ; impl: @mplBuiltinFieldName               ;}
   {name: "floor"                   ; impl: @mplBuiltinFloor                   ;}
+  {name: "getCallTrace"            ; impl: @mplBuiltinGetCallTrace            ;}
   {name: "has"                     ; impl: @mplBuiltinHas                     ;}
   {name: "HAS_LOGS"                ; impl: @mplBuiltinHasLogs                 ;}
   {name: "if"                      ; impl: @mplBuiltinIf                      ;}

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -3,7 +3,7 @@
 
 failProcForProcessor: [
   failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr];
-  copy message:;
+  message:;
   "ASSERTION FAILED!!!" print LF print
   message print LF print
   "While compiling:" print LF print
@@ -49,11 +49,15 @@ defaultSet: [
       refToSrc getVar.data.getTag VarImport = [
         "functions cannot be copied" compilerError
       ] [
-        refToDst.mutable [
-          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
-          refToSrc refToDst createCopyToExists
+        refToSrc getVar.data.getTag VarString = [
+          "builtin-strings cannot be copied" compilerError
         ] [
-          "destination is immutable" compilerError
+          refToDst.mutable [
+            [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
+            refToSrc refToDst createCopyToExists
+          ] [
+            "destination is immutable" compilerError
+          ] if
         ] if
       ] if
     ] [
@@ -105,6 +109,8 @@ defaultUseOrIncludeModule: [
       varName.data.getTag VarString = not ["name must be static string" compilerError] when
     ] [
       string: VarString varName.data.get;
+      ("use or include module " string) addLog
+
       fr: string makeStringView processor.modules.find;
       fr.success [fr.value 0 < not] && [
         frn: fr.value currentNode.usedModulesTable.find;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -69,6 +69,8 @@
   "" makeStringView addStrToProlog
   ("mainPath is \"" makeStringView processor.options.mainPath makeStringView "\"" makeStringView) addLog
 
+  processor.options.callTrace [createCallTraceData] when
+
   addLinkerOptionsDebugInfo
 
   processor.options.debug [
@@ -221,7 +223,7 @@
     ("max depth of recursion=" processor.maxDepthOfRecursion) addLog
 
     processor.usedFloatBuiltins [createFloatBuiltins] when
-    createCtors
+    processor.options.callTrace processor.options.threadModel 1 = and createCtors
     createDtors
     clearUnusedDebugInfo
     addAliasesForUsedNodes

--- a/variable.mpl
+++ b/variable.mpl
@@ -13,6 +13,7 @@ Dynamic:         [1n8 dynamic];
 Weak:            [2n8 dynamic];
 Static:          [3n8 dynamic];
 Virtual:         [4n8 dynamic];
+Schema:          [5n8 dynamic];
 
 NameCaseInvalid:               [ 0n8 dynamic];
 NameCaseBuiltin:               [ 1n8 dynamic];
@@ -56,10 +57,12 @@ hash: ["REF_TO_VAR" has] [
   l:r:;;
   l.index r.index =
 ] pfunc;
+
 NameInfoEntry: [{
   refToVar: RefToVar;
   startPoint: -1 dynamic; # id of node
   nameCase: NameCaseInvalid;
+  index: -1 dynamic; # for NameCaseSelfMember
 }];
 
 Overload: [NameInfoEntry Array];
@@ -127,30 +130,30 @@ CodeNodeInfo: [{
 Variable: [{
   VARIABLE: ();
 
-  mplNameId: -1 dynamic;
-  irNameId: -1 dynamic;
-  mplTypeId: -1 dynamic;
-  irTypeId: -1 dynamic;
-  dbgTypeId: -1 dynamic;
-  storageStaticness: Static;
-  staticness: Static;
-  global: FALSE dynamic;
-  temporary: TRUE dynamic;
-  usedInHeader: FALSE dynamic;
-  capturedAsMutable: FALSE dynamic;
-  capturedAsRealValue: FALSE dynamic;
-  tref: TRUE dynamic;
-  shadowReason: ShadowReasonNo;
-  globalId: -1 dynamic;
-  shadowBegin: RefToVar;
-  shadowEnd: RefToVar;
-  capturedHead: RefToVar;
-  capturedTail: RefToVar;
-  capturedPrev: RefToVar;
-  realValue: RefToVar;
+  mplNameId:                         -1 dynamic;
+  irNameId:                          -1 dynamic;
+  mplTypeId:                         -1 dynamic;
+  irTypeId:                          -1 dynamic;
+  dbgTypeId:                         -1 dynamic;
+  storageStaticness:                 Static;
+  staticness:                        Static;
+  global:                            FALSE dynamic;
+  temporary:                         TRUE dynamic;
+  usedInHeader:                      FALSE dynamic;
+  capturedAsMutable:                 FALSE dynamic;
+  capturedAsRealValue:               FALSE dynamic;
+  tref:                              TRUE dynamic;
+  shadowReason:                      ShadowReasonNo;
+  globalId:                          -1 dynamic;
+  shadowBegin:                       RefToVar;
+  shadowEnd:                         RefToVar;
+  capturedHead:                      RefToVar;
+  capturedTail:                      RefToVar;
+  capturedPrev:                      RefToVar;
+  realValue:                         RefToVar;
   globalDeclarationInstructionIndex: -1 dynamic;
-  allocationInstructionIndex: -1 dynamic;
-  getInstructionIndex: -1 dynamic;
+  allocationInstructionIndex:        -1 dynamic;
+  getInstructionIndex:               -1 dynamic;
 
   data: (
     Nat8             #VarInvalid
@@ -376,7 +379,7 @@ getVar: [
 ];
 
 getNameById: [processor.nameBuffer.at makeStringView];
-getMplName:  [getVar.mplNameId getNameById];
+getMplName:  [getVar.mplNameId processor.nameInfos.at.name makeStringView];
 getIrName:   [getVar.irNameId getNameById];
 getMplType:  [getVar.mplTypeId getNameById];
 getIrType:   [getVar.irTypeId getNameById];
@@ -477,7 +480,7 @@ isNat: [
 isAnyInt: [
   refToVar:;
   refToVar isInt
-  [ refToVar isNat ] ||
+  [refToVar isNat] ||
 ];
 
 isReal: [
@@ -505,8 +508,13 @@ isTinyArg: [
   refToVar isPlain [
     var: refToVar getVar;
     var.data.getTag VarRef =
-    [var.data.getTag VarString =] ||
   ] ||
+];
+
+isUnallocable: [
+  var: getVar;
+  var.data.getTag VarString =
+  [var.data.getTag VarImport =] ||
 ];
 
 isStruct: [
@@ -590,7 +598,10 @@ getSingleDataStorageSize: [
     VarReal32  [4nx]
     VarReal64  [8nx]
     VarRef     [processor.options.pointerSize 8nx /]
-    VarString  [processor.options.pointerSize 8nx /]
+    VarString  [
+      "strings dont have storageSize and alignment" compilerError
+      0nx
+    ]
     VarImport  [
       "functions dont have storageSize and alignment" compilerError
       0nx
@@ -694,7 +705,7 @@ getNonrecursiveDataIRType: [
     result: String;
     var: refToVar getVar;
     var.data.getTag VarString = [
-      "i8*" toString @result set
+      "i8" toString @result set
     ] [
       var.data.getTag VarImport = [
         VarImport var.data.get getFuncIrType toString @result set
@@ -883,10 +894,10 @@ fullUntemporize: [
   ] when
 ];
 
-isVirtualRef: [
+isSchema: [
   refToVar:;
   var: refToVar getVar;
-  var.data.getTag VarRef = [var.staticness Virtual =] &&
+  var.data.getTag VarRef = [var.staticness Schema =] &&
 ];
 
 isVirtualType: [
@@ -896,14 +907,14 @@ isVirtualType: [
   var.data.getTag VarBuiltin =
   [var.data.getTag VarCode =] ||
   [var.data.getTag VarStruct = [VarStruct var.data.get.get.fullVirtual copy] &&] ||
-  [refToVar isVirtualRef] ||
+  [refToVar isSchema] ||
 ];
 
 isVirtual: [
   refToVar:;
 
   var: refToVar getVar;
-  var.staticness Virtual =
+  var.staticness Virtual < not
   [refToVar isVirtualType] ||
 ];
 
@@ -916,7 +927,7 @@ isVirtualField: [
   refToVar:;
 
   var: refToVar getVar;
-  var.staticness Virtual =
+  var.staticness Virtual < not
   [refToVar isVirtualType] ||
 ];
 
@@ -935,6 +946,7 @@ getVirtualValue: [
   recursive
   var: refToVar getVar;
   result: String;
+
   var.data.getTag (
     VarStruct [
       "{" @result.cat
@@ -943,22 +955,33 @@ getVirtualValue: [
       struct.fields [
         pair:;
         pair.index 0 > ["," @result.cat] when
-        pair.value.refToVar getVirtualValue @result.cat
+        pair.value.refToVar isVirtualField not [
+          pair.value.refToVar getVirtualValue @result.cat
+        ] when
       ] each
       "}" @result.cat
-    ]
-
-    VarString  [
-      string: VarString var.data.get;
-      (string textSize "_" string getStringImplementation) @result.catMany
     ]
     VarCode    [
       info: VarCode    var.data.get;
       ("\"" info.moduleId processor.options.fileNames.at getStringImplementation "\"/" info.line ":" info.column) @result.catMany
     ]
-    VarImport  [VarImport  var.data.get @result.cat]
     VarBuiltin [VarBuiltin var.data.get @result.cat]
-    VarRef     ["."                     @result.cat]
+    VarRef     [
+      pointee: VarRef var.data.get;
+      pointeeVar: pointee getVar;
+      var.staticness Schema = [
+        "." @result.cat
+      ] [
+        pointeeVar.data.getTag (
+          VarString  [
+            string: VarString pointeeVar.data.get;
+            (string textSize "_" string getStringImplementation) @result.catMany
+          ]
+          VarImport  [VarImport  pointeeVar.data.get @result.cat]
+          [[FALSE] "Wrong type for virtual reference!" assert]
+        ) case
+      ] if
+    ]
     [
       refToVar isPlain [
         refToVar getPlainConstantIR @result.cat


### PR DESCRIPTION
# Language changes

- ### Built-in string literals
    - Built-in string literals are stored in read-only memory and accessible for users only by pointers. Before string literal were leaving value-type on the stack, but semantically it was behaving like a reference
    - From now on string literal leave reference to a value of some internal type. It is unavailable to have a value of this type, only a reference to it, same as with `codeRef`
    - `copy`, `storageSize` and `alignment` built-ins are no longer applicable to built-in string literals, for there is no more sense in that
- ### `getCallTrace` `( -- ( TraceElement ) )` built-in
    - Built-in returns list with information about call stack. Each element contains a file name, line number, and position in line. This built-in could be enabled by compiler option `-call_trace`
Example:
```
trace: getCallTrace;  
[
  trace.first trace.last is [
    FALSE
  ] [
    () LF printf
    (trace.last.name trace.last.line copy trace.last.column copy)
    "in %s at %i:%i" printf
    trace.last.prev trace.last addressToReference @trace.!last
    TRUE
  ] if
] loop
```
# Compiler changes
- ### `-call_trace x` compiler option
    - `-call_trace 0` --- no trace
    - `-call_trace 1` enables trace only for single-threaded application
    - `-call_trace 2` enables trace for any application for x86, thread-safe
- ### Improved error output
    - Compiler points out to a local variable, that was captured in a context that could potentially outlive that variable scope
```
# test.mpl
[
  x: 1;
  f: {} {} {} codeRef;
  [a: x;] !f
] call

->

test.mpl(5,7): error, [x], real function can not have real local capture
test.mpl(5,11): [!f], called from here
test.mpl(6,3): [call], called from here
```
- ### Improved function matching performance
# Bug fixes
- #### Fixed type of the argument that was declared as reference
```   
# test.mpl
{in: 0nx 0 addressToReference const;} () {} [
  printStack drop:;
] "load" exportFunction
```
Before:
```
> mplc -o test.ll test.mpl
stack:
depth=1
i32CC
```
After:
```
> mplc -o test.ll test.mpl
stack:
depth=1
i32C
```

- #### Fixed compilation fault for an overloaded function-member that uses a non-virtual variable of its own
```
# test.mpl
Obj: {
  fun: {
    CALL: [val];
    val:  42;
  };

  fun: {PRE:[FALSE]; CALL:[];};
};

[Obj.fun] call _:;
```
Before:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Wrong refToVar!
...
```
After:
```
> mplc -o test.ll test.mpl

```    

- #### Fixed visibility issues for overloads when member-function were called from `ASSIGN`, `CALL`, `DIE` or `INIT`:
```
#test.mpl

f: [];

g: {
  CALL: [f];

  f: {
    PRE:[0 same]; CALL:[do];
    do: [_:; f];
  };
};

0 g
```
Before:
```
> mplc -o test.ll test.mpl
test.mpl(8,14): error, [f], unknown name:f
test.mpl(7,25): [do], called from here
test.mpl(4,10): [f], called from here
test.mpl(12,3): [g], called from here
```
After:
```
> mplc -o test.ll test.mpl
```

- #### Fixed double call of non-virtual function from a recursive function 
```
# test.mpl
{} {} {} "F" importFunction

print: [
  recursive
  [
    a:;
    a 0 > [
      0 print
    ] [] if
  ] call
  F
];

() () {} [
  1 print
] "main" exportFunction
```
Before:
```
> mplc -ndebug -o test.ll test.mpl

# part of test.ll
define internal void @func.11.print(i32* %var.3) {
label1:
  call void @func.14.call(i32* %var.3)
  call void @F()
  call void @F()
  ret void
}
```
After:
```
> mplc -call_trace 0 -ndebug -o test.ll test.mpl

# part of test.ll
define internal void @func.11.print(i32* %var.3) {
label1:
  call void @func.14.call(i32* %var.3)
  call void @F()
  ret void
}
```

- #### Fixed crash on attempt to assign a virtual value that was indirectly marked `dynamic`
```
# test.mpl
 _: 0 [dynamic] call virtual;
```
Before:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Index out of range!
While compiling: at filename: ../test.mpl, token: _: nodeIndex: 2, line 2, column 1
```
After:
```
> mplc -o test.ll test.mpl
test.mpl(2,2): error, [_:], value for virtual label must be static
```

- #### Fixed crash on attempt to mark schema `dynamic`
```
# test.mpl
a: 0 schema;
a dynamic
```
Before:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Ref must be only Static or Dynamic!
at filename: test.mpl, token: dynamic, line: 2, column: 3
```
After:
```
> mplc -o test.ll test.mpl
test.mpl(3,3): error, [dynamic], can't dynamize schema
```

- #### Fixed crash on attempt to create an object with virtual field initialized by virtual string literal
```
# test.mpl
a: "" virtual;
x: {a: a virtual;};
```
Before:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Ref got from parent, but dont have shadow!
While compiling:
at filename: test.mpl, token: {, nodeIndex: 2, line: 3, column: 4
stack:
depth=0
Terminating...
```
After:
```
> mplc -o test.ll test.mpl
```

- #### Fixed hanging on attempt to create an object with a field that contains schema of some virtual extrnal value
```
# test.mpl
virtual a: "";
{a schema b:;}
```
Before:
```
> mplc test.mpl -o test.ll 
(does not terminate)
```
After:
```
> mplc test.mpl -o test.ll
(terminates)
```

- #### Fixed incorrect matching resolution if it's based on result of calling an argument
```
# test.mpl
fact: [[] [0.AssertionFiled] uif]; #! condition

ok?: [_:; FALSE];
ok?: {PRE: [call TRUE]; CALL: [_:; TRUE];};

empty?: [[_:;] ok? ~];

empty? fact
42 empty? ~ fact _:;
```
Before:
```
> mplc -o test.ll test.mpl
test.mpl(1,13): error, [.AssertionFiled], not a combined
test.mpl(9,12): [fact], called from here
```
After:
```
> mplc -o test.ll test.mpl
```


