### PR TITLE
Incremental update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a self-hosted MPL compiler.
 ## Building
 
 Because the MPL Compiler is self-hosted, you cannot build it without MPL Compiler.
-To help with bootstrapping, we provide precompiled `mplc.ll` files, see releases.
+To help with bootstrapping, we provide precompiled `mplc.ll` files, see [releases](https://github.com/Matway/mpl-c/releases).
 
 ### Prerequisites
 

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -851,7 +851,7 @@ parseSignature: [
           returnVar.temporary [
             return @result.@outputs.pushBack
           ] [
-            return return.mutable createRef @result.@outputs.pushBack
+            return TRUE dynamic createRef @result.@outputs.pushBack
           ] if
         ] if
       ] when
@@ -901,7 +901,7 @@ parseSignature: [
       refToVar isVirtual ["cannot export virtual var" compilerError] when
     ] [
       refToVar getVar.temporary not [
-        refToVar refToVar.mutable createRef @refToVar set
+        refToVar TRUE dynamic createRef @refToVar set
       ] when
       var: refToVar getVar;
       FALSE @var.@temporary set
@@ -981,7 +981,7 @@ parseSignature: [
             "variable cant be virtual" compilerError
           ] [
             varType.temporary not [
-              refToType refToType.mutable createRef @refToType set
+              refToType TRUE dynamic createRef @refToType set
             ] when
 
             name: VarString varName.data.get;

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1041,7 +1041,7 @@ parseSignature: [
   refToVar: pop;
   compilable [
     result: refToVar copyVarToNew;
-    result isVirtual not [
+    result isVirtual not [result isUnallocable not] && [
       TRUE @result.@mutable set
       result createAllocIR callInit
     ] when

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -1671,6 +1671,60 @@ parseSignature: [
 ] "mplBuiltinArray" @declareBuiltin ucall
 
 [
+  varPrev:   0n64 VarNatX createVariable;
+  varNext:   0n64 VarNatX createVariable;
+  varName:   String makeVarString TRUE dynamic createRefNoOp;
+  varLine:   0i64 VarInt32 createVariable;
+  varColumn: 0i64 VarInt32 createVariable;
+
+  varPrev   makeVarDirty
+  varNext   makeVarDirty
+  varName   makeVarDirty
+  varLine   makeVarDirty
+  varColumn makeVarDirty
+
+  struct: Struct;
+  5 @struct.@fields.resize
+
+  varPrev             0 @struct.@fields.at.@refToVar set
+  "prev" findNameInfo 0 @struct.@fields.at.@nameInfo set
+
+  varNext             1 @struct.@fields.at.@refToVar set
+  "next" findNameInfo 1 @struct.@fields.at.@nameInfo set
+
+  varName             2 @struct.@fields.at.@refToVar set
+  "name" findNameInfo 2 @struct.@fields.at.@nameInfo set
+
+  varLine             3 @struct.@fields.at.@refToVar set
+  "line" findNameInfo 3 @struct.@fields.at.@nameInfo set
+  
+  varColumn             4 @struct.@fields.at.@refToVar set
+  "column" findNameInfo 4 @struct.@fields.at.@nameInfo set
+
+  first: @struct move owner VarStruct createVariable;
+  last: first copyVar;
+
+  firstRef: first FALSE dynamic createRefNoOp;
+  lastRef:  last  FALSE dynamic createRefNoOp;
+
+  firstRef makeVarDirty
+  lastRef  makeVarDirty
+
+  resultStruct: Struct;
+  2 @resultStruct.@fields.resize
+
+  firstRef             0 @resultStruct.@fields.at.@refToVar set
+  "first" findNameInfo 0 @resultStruct.@fields.at.@nameInfo set
+
+  lastRef             1 @resultStruct.@fields.at.@refToVar set
+  "last" findNameInfo 1 @resultStruct.@fields.at.@nameInfo set
+
+  result: @resultStruct move owner VarStruct createVariable createAllocIR;
+  first getIrType result getIrType result createGetCallTrace
+  result push
+] "mplBuiltinGetCallTrace" @declareBuiltin ucall
+
+[
   refToVar: pop;
   compilable [
     refToVar.mutable [

--- a/builtins.mpl
+++ b/builtins.mpl
@@ -41,6 +41,7 @@ builtins: (
   {name: "fieldIndex"              ; impl: @mplBuiltinFieldIndex              ;}
   {name: "fieldName"               ; impl: @mplBuiltinFieldName               ;}
   {name: "floor"                   ; impl: @mplBuiltinFloor                   ;}
+  {name: "getCallTrace"            ; impl: @mplBuiltinGetCallTrace            ;}
   {name: "has"                     ; impl: @mplBuiltinHas                     ;}
   {name: "HAS_LOGS"                ; impl: @mplBuiltinHasLogs                 ;}
   {name: "if"                      ; impl: @mplBuiltinIf                      ;}

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -214,7 +214,7 @@ createVariableWithVirtual: [
   result result getVar.@capturedHead set
   result result getVar.@capturedTail set
 
-  result isNonrecursiveType not @result.@mutable set
+  result isNonrecursiveType not [result isUnallocable not] && @result.@mutable set
 
   makeType [result makeVariableType] when
   result makeVariableIRName

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -343,9 +343,12 @@ getPointeeWith: [
     ] [
       pointeeGDI: pointee getVar.globalDeclarationInstructionIndex;
       fromParent [ # capture or argument
-        [var.shadowBegin.hostId 0 < not] "Ref got from parent, but dont have shadow!" assert
-        varShadow: var.shadowBegin getVar;
-        pointeeOfShadow: VarRef @varShadow.@data.get;
+        varShadow: refToVar copy;
+        refToVar noMatterToCopy not [
+          [var.shadowBegin.hostId 0 < not] "Ref got from parent, but dont have shadow!" assert
+          var.shadowBegin @varShadow set
+        ] when
+        pointeeOfShadow: VarRef @varShadow getVar.@data.get;
 
         pointeeOfShadow.hostId indexOfNode = [ # just made deref from another place
           pointeeOfShadowVar: pointeeOfShadow getVar;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1156,12 +1156,11 @@ getNameAs: [
 
   nameInfo 0 < not [
     curNameInfo: nameInfo processor.nameInfos.at;
-
     curNameInfo.name name = [
-      overload 0 < [curNameInfo.stack.dataSize 1 - @overload set] when
+      overload 0 < [curNameInfo.stack.getSize 1 - @overload set] when
 
-      curNameInfo.stack.dataSize 0 > [overload curNameInfo.stack.at.dataSize 0 >] && [
-        [curNameInfo.stack.dataSize 0 >] "Name info data not initialised!" assert
+      curNameInfo.stack.getSize 0 > [overload curNameInfo.stack.at.getSize 0 >] && [
+        [curNameInfo.stack.getSize 0 >] "Name info data not initialised!" assert
         nameInfoEntry: overload curNameInfo.stack.at.last;
         overload @result.@nameOverload set
         nameInfoEntry.nameCase   @result.@nameCase set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1574,7 +1574,7 @@ callCallableStructWithPre: [
         findInside [
           fr: nameInfo object overloadShift findFieldWithOverloadShift;
           fr.success [
-            fr.index object getField @refToVar set
+            fr.index object processStaticAt @refToVar set
           ] [
             0 @overloadShift set
             FALSE @findInside set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -980,7 +980,7 @@ createNamedVariable: [
     ] when
 
     nameInfo newRefToVar NameCaseLocal addNameInfo
-    processor.options.debug [newRefToVar isVirtual not] && [
+    compilable [processor.options.debug copy] && [newRefToVar isVirtual not] && [
       newRefToVar isGlobal [
         d: nameInfo newRefToVar addGlobalVariableDebugInfo;
         globalInstruction: newRefToVar getVar.globalDeclarationInstructionIndex @processor.@prolog.at;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1814,7 +1814,7 @@ copyVarImpl: [
   copy fromChildToParent:;
   refToVar:;
 
-  fromChildToParent toNew or [refToVar noMatterToCopy] && [
+  fromChildToParent toNew or [refToVar noMatterToCopy refToVar isUnallocable or] && [
     refToVar copy
   ] [
     result: RefToVar;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1197,6 +1197,7 @@ getNameForMatchingWithOverload: [
 
 captureName: [
   getNameResult:;
+  compileOnce
 
   result: {
     refToVar: RefToVar;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -591,13 +591,14 @@ createRefWith: [
     refToVar untemporize
     refToVar copy #for dropping or getting callables for example
   ] [
-    var: refToVar getVar;
-    refToVar staticnessOfVar Weak = [Dynamic @var.@staticness set] when
-    refToVar fullUntemporize
+    pointee: refToVar copy;
+    var: pointee getVar;
+    pointee staticnessOfVar Weak = [Dynamic @var.@staticness set] when
+    pointee fullUntemporize
 
-    newRefToVar: refToVar VarRef createVariable;
-    mutable refToVar.mutable and @newRefToVar.@mutable set
-    createOperation [refToVar newRefToVar createRefOperation] when
+    pointee.mutable [mutable copy] && @pointee.@mutable set
+    newRefToVar: pointee VarRef createVariable;
+    createOperation [pointee newRefToVar createRefOperation] when
     newRefToVar
   ] if
 ];
@@ -2570,7 +2571,7 @@ finalizeListNode: [
         curRef getVar.temporary [
           curRef @newField.@refToVar set
         ] [
-          curRef FALSE createRef @newField.@refToVar set
+          curRef TRUE dynamic createRef @newField.@refToVar set
         ] if
 
         newField @struct.@fields.pushBack

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -807,6 +807,7 @@ makeVarTreeDirty: [
 
       var: lastRefToVar getVar;
       lastRefToVar staticnessOfVar Virtual = ["can't dynamize virtual value" makeStringView compilerError] when
+      lastRefToVar staticnessOfVar Schema = ["can't dynamize schema" makeStringView compilerError] when
 
       compilable [
         var.data.getTag VarStruct = [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3698,6 +3698,7 @@ nodeHasCode: [
     @currentNode.@labelNames.clear
     @currentNode.@fromModuleNames.clear
     @currentNode.@captureNames.clear
+    @currentNode.@unprocessedAstNodes.clear
 
     processor.options.debug [
       addDebugReserve @currentNode.@funcDbgIndex set

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -2202,7 +2202,12 @@ addCodeNode: [
 
 argAbleToCopy: [
   arg:;
-  arg.mutable not [arg isTinyArg] &&
+  arg isTinyArg
+];
+
+argRecommendedToCopy: [
+  arg:;
+  arg.mutable not [arg argAbleToCopy] && [arg getVar.capturedAsMutable not] &&
 ];
 
 callInit: [
@@ -3122,7 +3127,7 @@ makeCompilerPosition: [
             needToCopy: hasForcedSignature [
               i forcedSignature.inputs.at getVar.data.getTag VarRef = not
             ] [
-              current.refToVar argAbleToCopy [current.refToVar getVar.capturedAsMutable not] &&
+              current.refToVar argRecommendedToCopy
             ] if;
 
             needToCopy [current.refToVar argAbleToCopy not] && [isRealFunction copy] && [

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -682,6 +682,7 @@ makeVirtualVarReal: [
       @result makeVariableType
       refToVar @unfinishedSrc.pushBack
       result createAllocIR @unfinishedDst.pushBack
+
       [
         unfinishedSrc.dataSize 0 > [
           lastSrc: unfinishedSrc.last copy;

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -105,6 +105,8 @@ defaultUseOrIncludeModule: [
       varName.data.getTag VarString = not ["name must be static string" compilerError] when
     ] [
       string: VarString varName.data.get;
+      ("use or include module " string) addLog
+
       fr: string makeStringView processor.modules.find;
       fr.success [fr.value 0 < not] && [
         frn: fr.value currentNode.usedModulesTable.find;

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -49,11 +49,15 @@ defaultSet: [
       refToSrc getVar.data.getTag VarImport = [
         "functions cannot be copied" compilerError
       ] [
-        refToDst.mutable [
-          [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
-          refToSrc refToDst createCopyToExists
+        refToSrc getVar.data.getTag VarString = [
+          "builtin-strings cannot be copied" compilerError
         ] [
-          "destination is immutable" compilerError
+          refToDst.mutable [
+            [refToDst staticnessOfVar Weak = not] "Destination is weak!" assert
+            refToSrc refToDst createCopyToExists
+          ] [
+            "destination is immutable" compilerError
+          ] if
         ] if
       ] if
     ] [

--- a/defaultImpl.mpl
+++ b/defaultImpl.mpl
@@ -3,7 +3,7 @@
 
 failProcForProcessor: [
   failProc: [stringMemory printAddr " - fail while handling fail" stringMemory printAddr];
-  copy message:;
+  message:;
   "ASSERTION FAILED!!!" print LF print
   message print LF print
   "While compiling:" print LF print

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -473,7 +473,6 @@ createCallIR: [
 
   haveRet [
     generateRegisterIRName @retName set
-
     ("  " @retName getNameById " = call " conventionName refToRet getIrType " ") @operation.catMany
   ] [
     ("  call " conventionName "void ") @operation.catMany

--- a/irWriter.mpl
+++ b/irWriter.mpl
@@ -642,25 +642,30 @@ addAliasesForUsedNodes: [
 ];
 
 createCallTraceData: [
+  tlPrefix: processor.options.threadModel 1 = ["thread_local "] [""] if;
+
   callTraceDataType: "[65536 x %type.callTraceInfo]" toString;
   "%type.callTraceInfo = type {%type.callTraceInfo*, %type.callTraceInfo*, i8*, i32, i32}" toString @processor.@prolog.pushBack
-  ("@debug.callTrace = thread_local unnamed_addr global " callTraceDataType " zeroinitializer") assembleString @processor.@prolog.pushBack
-  ("@debug.callTracePtr = thread_local unnamed_addr global %type.callTraceInfo* getelementptr inbounds (" callTraceDataType ", " callTraceDataType "* @debug.callTrace, i32 0, i32 0)") assembleString @processor.@prolog.pushBack
-  String @processor.@prolog.pushBack
-  "@\"__tls_init$initializer$\" = internal constant void ()* @__tls_init, section \".CRT$XDU\"" toString @processor.@prolog.pushBack
-  "@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()** @\"__tls_init$initializer$\" to i8*)], section \"llvm.metadata\"" toString @processor.@prolog.pushBack
-  String @processor.@prolog.pushBack
-  "define internal void @__tls_init() {" toString @processor.@prolog.pushBack
-  ("  store %type.callTraceInfo* getelementptr inbounds (" callTraceDataType ", " callTraceDataType "* @debug.callTrace, i32 0, i32 0), %type.callTraceInfo** @debug.callTracePtr") assembleString @processor.@prolog.pushBack
-  "  ret void" toString @processor.@prolog.pushBack
-  "}" toString @processor.@prolog.pushBack
-  String @processor.@prolog.pushBack
+  ("@debug.callTrace = " tlPrefix "unnamed_addr global " callTraceDataType " zeroinitializer") assembleString @processor.@prolog.pushBack
+  ("@debug.callTracePtr = " tlPrefix "unnamed_addr global %type.callTraceInfo* getelementptr inbounds (" callTraceDataType ", " callTraceDataType "* @debug.callTrace, i32 0, i32 0)") assembleString @processor.@prolog.pushBack
 
-  processor.options.pointerSize 64nx = [
-    "/include:__dyn_tls_init" toString @processor.@options.@linkerOptions.pushBack
-  ] [
-    "/include:___dyn_tls_init@12" toString @processor.@options.@linkerOptions.pushBack
-  ] if
+  processor.options.threadModel 1 = [
+    String @processor.@prolog.pushBack
+    "@\"__tls_init$initializer$\" = internal constant void ()* @__tls_init, section \".CRT$XDU\"" toString @processor.@prolog.pushBack
+    "@llvm.used = appending global [1 x i8*] [i8* bitcast (void ()** @\"__tls_init$initializer$\" to i8*)], section \"llvm.metadata\"" toString @processor.@prolog.pushBack
+    String @processor.@prolog.pushBack
+    "define internal void @__tls_init() {" toString @processor.@prolog.pushBack
+    ("  store %type.callTraceInfo* getelementptr inbounds (" callTraceDataType ", " callTraceDataType "* @debug.callTrace, i32 0, i32 0), %type.callTraceInfo** @debug.callTracePtr") assembleString @processor.@prolog.pushBack
+    "  ret void" toString @processor.@prolog.pushBack
+    "}" toString @processor.@prolog.pushBack
+    String @processor.@prolog.pushBack
+
+    processor.options.pointerSize 64nx = [
+      "/include:__dyn_tls_init" toString @processor.@options.@linkerOptions.pushBack
+    ] [
+      "/include:___dyn_tls_init@12" toString @processor.@options.@linkerOptions.pushBack
+    ] if
+  ] when
 ];
 
 createCallTraceProlog: [

--- a/main.mpl
+++ b/main.mpl
@@ -175,6 +175,7 @@ createDefinition: [
                   option (
                     "0"   [0 @forceCallTrace set]
                     "1"   [1 @forceCallTrace set]
+                    "2"   [2 @forceCallTrace set]
                     [
                       "Invalid argument value: " print option print LF print
                       FALSE @success set
@@ -225,8 +226,11 @@ createDefinition: [
         forceCallTrace (
           0 [FALSE]
           1 [TRUE]
+          2 [TRUE]
           [options.debug copy]
         ) case @options.@callTrace set
+
+        forceCallTrace 2 = [1 @options.@threadModel set] when
 
         hasVersion [
           ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList

--- a/main.mpl
+++ b/main.mpl
@@ -210,6 +210,7 @@ createDefinition: [
       ] [
         "No input files" print LF print
         FALSE @success set
+        printInfo
       ] if
     ] [
       success not [

--- a/main.mpl
+++ b/main.mpl
@@ -15,6 +15,7 @@ printInfo: [
   "  -D <name[ =value]>  Define global name with value, default value is ()" print LF print
   "  -array_checks 0|1   Turn off/on array index checks, by default it is on in debug mode and off in release mode" print LF print
   "  -auto_recursion     Make all code block recursive-by-default" print LF print
+  "  -call_trace         Generate information about call trace" print LF print
   "  -dynalit            Number literals are dynamic constants, which are not used in analysis; default mode is static literals" print LF print
   "  -linker_option      Add linker option for LLVM" print LF print
   "  -logs               Value of \"HAS_LOGS\" constant in code turn to TRUE" print LF print
@@ -85,6 +86,7 @@ createDefinition: [
     OPT_LINKER_OPTION:      [3 dynamic];
     OPT_DEFINITION:         [4 dynamic];
     OPT_ARRAY_CHECK:        [5 dynamic];
+    OPT_CALL_TRACE:         [6 dynamic];
     nextOption: OPT_ANY;
 
     options: ProcessorOptions;
@@ -95,6 +97,7 @@ createDefinition: [
     outputFileName: "mpl.ll" toString;
 
     forceArrayChecks: -1 dynamic;
+    forceCallTrace: -1 dynamic;
 
     "*definitions" toString @options.@fileNames.pushBack
 
@@ -134,6 +137,7 @@ createDefinition: [
                     "-o"              [OPT_OUTPUT_FILE_NAME !nextOption]
                     "-D"              [OPT_DEFINITION       !nextOption]
                     "-array_checks"   [OPT_ARRAY_CHECK      !nextOption]
+                    "-call_trace"     [OPT_CALL_TRACE       !nextOption]
                     [
                       0 splittedOption.chars.at "-" = [
                         "Invalid argument: " print option print LF print
@@ -167,6 +171,16 @@ createDefinition: [
                   ) case
                   OPT_ANY !nextOption
                 ]
+                OPT_CALL_TRACE     [
+                  option (
+                    "0"   [0 @forceCallTrace set]
+                    "1"   [1 @forceCallTrace set]
+                    [
+                      "Invalid argument value: " print option print LF print
+                      FALSE @success set
+                    ]
+                  ) case
+                  OPT_ANY !nextOption
                 ]
                 []
               ) case
@@ -207,6 +221,12 @@ createDefinition: [
         1 [TRUE]
         [options.debug copy]
       ) case @options.@arrayChecks set
+
+      forceCallTrace (
+        0 [FALSE]
+        1 [TRUE]
+        [options.debug copy]
+      ) case @options.@callTrace set
 
       hasVersion [
         ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList

--- a/main.mpl
+++ b/main.mpl
@@ -211,93 +211,93 @@ createDefinition: [
         "No input files" print LF print
         FALSE @success set
       ] if
-    ] when
-
-    success not [
-      printInfo
     ] [
-      forceArrayChecks (
-        0 [FALSE]
-        1 [TRUE]
-        [options.debug copy]
-      ) case @options.@arrayChecks set
-
-      forceCallTrace (
-        0 [FALSE]
-        1 [TRUE]
-        [options.debug copy]
-      ) case @options.@callTrace set
-
-      hasVersion [
-        ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList
-        "Input files ignored" print LF print
+      success not [
+        printInfo
       ] [
-        options.fileNames [
-          pair:;
-          filename: pair.value;
+        forceArrayChecks (
+          0 [FALSE]
+          1 [TRUE]
+          [options.debug copy]
+        ) case @options.@arrayChecks set
 
-          pair.index 0 = [
-            filename pair.index definitions addToProcess
-          ] [
-            loadStringResult: filename loadString;
-            loadStringResult.success [
-              ("Loaded string from " filename) addLog
-              ("HASH=" loadStringResult.data hash) addLog
-              filename pair.index loadStringResult.data addToProcess
+        forceCallTrace (
+          0 [FALSE]
+          1 [TRUE]
+          [options.debug copy]
+        ) case @options.@callTrace set
+
+        hasVersion [
+          ("MPL compiler version " COMPILER_SOURCE_VERSION LF) printList
+          "Input files ignored" print LF print
+        ] [
+          options.fileNames [
+            pair:;
+            filename: pair.value;
+
+            pair.index 0 = [
+              filename pair.index definitions addToProcess
             ] [
-              "Unable to load string:" print filename print LF print
-              FALSE @success set
-            ] if
-          ] if
-        ] each
-
-        success [
-          multiParserResult: MultiParserResult;
-          @parserResults @multiParserResult concatParserResults
-          ("trees concated" makeStringView) addLog
-          @multiParserResult optimizeNames
-          ("names optimized" makeStringView) addLog
-
-          ("filenames:" makeStringView) addLog
-          options.fileNames [(.value) addLog] each
-
-          processorResult: ProcessorResult;
-          multiParserResult options 0 @processorResult process
-          processorResult.success [
-            outputFileName @processorResult.@program saveString [
-              ("program written to " outputFileName) addLog
-            ] [
-              ("failed to save program" LF) printList
-              FALSE @success set
-            ] if
-          ] when
-
-          processorResult.success not [
-            processorResult.globalErrorInfo [
-              pair:;
-              current: pair.value;
-              pair.index 0 > [LF print] when
-              current.position.getSize 0 = [
-                ("error, "  current.message) printList LF print
+              loadStringResult: filename loadString;
+              loadStringResult.success [
+                ("Loaded string from " filename) addLog
+                ("HASH=" loadStringResult.data hash) addLog
+                filename pair.index loadStringResult.data addToProcess
               ] [
-                current.position [
-                  pair:;
-                  i: pair.index;
-                  nodePosition: pair.value;
-                  (nodePosition.fileNumber options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
-
-                  i 0 = [
-                    ("error, [" nodePosition.token "], " current.message LF) printList
-                  ] [
-                    ("[" nodePosition.token "], called from here" LF) printList
-                  ] if
-                ] each
+                "Unable to load string:" print filename print LF print
+                FALSE @success set
               ] if
+            ] if
+          ] each
 
-              FALSE @success set
-            ] each
+          success [
+            multiParserResult: MultiParserResult;
+            @parserResults @multiParserResult concatParserResults
+            ("trees concated" makeStringView) addLog
+            @multiParserResult optimizeNames
+            ("names optimized" makeStringView) addLog
+
+            ("filenames:" makeStringView) addLog
+            options.fileNames [(.value) addLog] each
+
+            processorResult: ProcessorResult;
+            multiParserResult options 0 @processorResult process
+            processorResult.success [
+              outputFileName @processorResult.@program saveString [
+                ("program written to " outputFileName) addLog
+              ] [
+                ("failed to save program" LF) printList
+                FALSE @success set
+              ] if
+            ] when
+
+            processorResult.success not [
+              processorResult.globalErrorInfo [
+                pair:;
+                current: pair.value;
+                pair.index 0 > [LF print] when
+                current.position.getSize 0 = [
+                  ("error, "  current.message) printList LF print
+                ] [
+                  current.position [
+                    pair:;
+                    i: pair.index;
+                    nodePosition: pair.value;
+                    (nodePosition.fileNumber options.fileNames.at "(" nodePosition.line  ","  nodePosition.column "): ") printList
+
+                    i 0 = [
+                      ("error, [" nodePosition.token "], " current.message LF) printList
+                    ] [
+                      ("[" nodePosition.token "], called from here" LF) printList
+                    ] if
+                  ] each
+                ] if
+
+                FALSE @success set
+              ] each
+            ] when
           ] when
-        ] when
+        ] if
       ] if
     ] if
 

--- a/main.mpl
+++ b/main.mpl
@@ -80,12 +80,12 @@ createDefinition: [
 
     success: TRUE dynamic;
 
-    optAny:            [0 dynamic];
-    optOutputFileName: [1 dynamic];
-    optLinkerOption:   [3 dynamic];
-    optDefinition:     [4 dynamic];
-    optArrayCheck:     [5 dynamic];
-    nextOption: optAny;
+    OPT_ANY:                [0 dynamic];
+    OPT_OUTPUT_FILE_NAME:   [1 dynamic];
+    OPT_LINKER_OPTION:      [3 dynamic];
+    OPT_DEFINITION:         [4 dynamic];
+    OPT_ARRAY_CHECK:        [5 dynamic];
+    nextOption: OPT_ANY;
 
     options: ProcessorOptions;
     hasVersion: FALSE dynamic;
@@ -119,7 +119,7 @@ createDefinition: [
               FALSE @success set
             ] [
               nextOption (
-                optAny [
+                OPT_ANY [
                   option (
                     "-auto_recursion" [TRUE              @options.!autoRecursion]
                     "-ndebug"         [FALSE             @options.!debug]
@@ -129,11 +129,11 @@ createDefinition: [
                     "-32bits"         [32nx              @options.!pointerSize]
                     "-64bits"         [64nx              @options.!pointerSize]
                     "-verbose_ir"     [TRUE              @options.!verboseIR]
-                    "-version"        [TRUE              !hasVersion]
-                    "-linker_option"  [optLinkerOption   !nextOption]
-                    "-o"              [optOutputFileName !nextOption]
-                    "-D"              [optDefinition     !nextOption]
-                    "-array_checks"   [optArrayCheck     !nextOption]
+                    "-version"        [TRUE                 !hasVersion]
+                    "-linker_option"  [OPT_LINKER_OPTION    !nextOption]
+                    "-o"              [OPT_OUTPUT_FILE_NAME !nextOption]
+                    "-D"              [OPT_DEFINITION       !nextOption]
+                    "-array_checks"   [OPT_ARRAY_CHECK      !nextOption]
                     [
                       0 splittedOption.chars.at "-" = [
                         "Invalid argument: " print option print LF print
@@ -144,19 +144,19 @@ createDefinition: [
                     ]
                   ) case
                 ]
-                optOutputFileName [
+                OPT_OUTPUT_FILE_NAME [
                   option toString @outputFileName set
-                  optAny !nextOption
+                  OPT_ANY !nextOption
                 ]
-                optLinkerOption   [
+                OPT_LINKER_OPTION   [
                   option toString @options.@linkerOptions.pushBack
-                  optAny !nextOption
+                  OPT_ANY !nextOption
                 ]
-                optDefinition     [
+                OPT_DEFINITION     [
                   splittedOption createDefinition
-                  optAny !nextOption
+                  OPT_ANY !nextOption
                 ]
-                optArrayCheck     [
+                OPT_ARRAY_CHECK     [
                   option (
                     "0"   [0 @forceArrayChecks set]
                     "1"   [1 @forceArrayChecks set]
@@ -165,7 +165,8 @@ createDefinition: [
                       FALSE @success set
                     ]
                   ) case
-                  optAny !nextOption
+                  OPT_ANY !nextOption
+                ]
                 ]
                 []
               ) case
@@ -175,7 +176,7 @@ createDefinition: [
       ] times
     ] if
 
-    nextOption optAny = not [
+    nextOption OPT_ANY = not [
       "Value expected" print LF print
       FALSE @success set
     ] when

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1955,8 +1955,12 @@ nSwap: [
     r makeVarTreeDynamic
     r unglobalize
     r fullUntemporize
-    FALSE @r.@mutable set
-    r push
+    r getVar.data.getTag VarRef = [
+      r getPointeeNoDerefIR push
+    ] [
+      FALSE @r.@mutable set
+      r push
+    ] if
   ] each
 
 

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -551,7 +551,7 @@ fixRef: [
   copy refToVar:;
 
   var: refToVar getVar;
-  wasVirtual: refToVar isVirtualRef;
+  wasVirtual: refToVar isSchema;
   makeDynamic: FALSE dynamic;
   pointee: VarRef @var.@data.get;
   pointeeVar: pointee getVar;
@@ -578,7 +578,7 @@ fixRef: [
   fixed.hostId @pointee.@hostId set
   fixed.varId  @pointee.@varId  set
 
-  wasVirtual [refToVar Virtual makeStaticness @refToVar set] [
+  wasVirtual [refToVar Schema makeStaticness @refToVar set] [
     makeDynamic [
       refToVar Dynamic makeStaticness @refToVar set
     ] when

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1908,22 +1908,6 @@ processDynamicLoop: [
   ] loop
 ];
 
-nSwap: [
-  copy n:;
-  [n currentNode.stask.getSize > not] "Swap count too big!" assert
-  i: 0;
-  j: n 1 -;
-  [i j <] [
-    e1: i getStackEntry;
-    e2: j getStackEntry;
-    tmp: e1 move;
-    e2 move @e1 set
-    tmp moce @e2 set
-    i 1 + @i set
-    j 1 - @j set
-  ] while
-];
-
 {processorResult: ProcessorResult Ref; processor: Processor Ref; indexOfNode: Int32; currentNode: CodeNode Ref; multiParserResult: MultiParserResult Cref;
   asLambda: Cond; name: StringView Cref; astNode: AstNode Cref; signature: CFunctionSignature Cref;} Int32 {convention: cdecl;} [
   processorResult:;

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1926,10 +1926,10 @@ processDynamicLoop: [
   positionInfo: astNode makeCompilerPosition;
   compileOnce
 
-
   signature.variadic [
     "export function cannot be variadic" compilerError
   ] when
+
   ("process export: " makeStringView name makeStringView) addLog
 
   # we dont know count of used in export entites
@@ -1947,7 +1947,6 @@ processDynamicLoop: [
     ] if
   ] each
 
-
   oldSuccess: compilable;
   oldRecursiveNodesStackSize: processor.recursiveNodesStack.getSize;
 
@@ -1956,7 +1955,6 @@ processDynamicLoop: [
     nodeCase: asLambda [NodeCaseLambda][NodeCaseExport] if;
     processor.exportDepth 1 + @processor.@exportDepth set
     name indexOfNode nodeCase @processorResult @processor indexArray multiParserResult positionInfo signature astNodeToCodeNode @newNodeIndex set
-
     processor.exportDepth 1 - @processor.@exportDepth set
   ] when
 

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -620,13 +620,6 @@ applyOnePair: [
         ] [
           ("match fail, type=" makeStringView cacheEntry getMplType makeStringView
             "; st=" makeStringView cacheEntry staticnessOfVar stackEntry staticnessOfVar) addLog
-
-          cg: cacheEntry isGlobal;
-          sg: stackEntry isGlobal;
-          cg sg = not [
-            ("globality fail cache " cacheEntry.hostId ":" cacheEntry.varId " g=" cg [1][0] if
-              "; stack " stackEntry.hostId ":" stackEntry.varId " g=" sg [1][0] if) addLog
-          ] when
           FALSE
         ] if
       ] "Applying var has wrong value!" assert

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -787,8 +787,8 @@ usePreCaptures: [
   currentChangesNodeIndex 0 < not [
     currentChangesNode: currentChangesNodeIndex processor.nodes.at.get;
 
-    oldSuccess: processorResult.success copy;
-    TRUE @processorResult.@success set
+    oldSuccess: @processorResult move copy;
+    -1 clearProcessorResult
 
     i: 0 dynamic;
     [
@@ -853,7 +853,7 @@ usePreCaptures: [
       ] &&
     ] loop
 
-    oldSuccess @processorResult.@success set
+    @oldSuccess move @processorResult set
   ] when
 ];
 
@@ -1970,10 +1970,10 @@ nSwap: [
   newNodeIndex: @indexArray tryMatchAllNodesForRealFunction;
   newNodeIndex 0 < [compilable] && [
     nodeCase: asLambda [NodeCaseLambda][NodeCaseExport] if;
-    processor.processingExport 1 + @processor.@processingExport set
+    processor.exportDepth 1 + @processor.@exportDepth set
     name indexOfNode nodeCase @processorResult @processor indexArray multiParserResult positionInfo signature astNodeToCodeNode @newNodeIndex set
 
-    processor.processingExport 1 - @processor.@processingExport set
+    processor.exportDepth 1 - @processor.@exportDepth set
   ] when
 
   newNodeIndex usePreCaptures

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -588,7 +588,7 @@ fixRef: [
   copy refToVar:;
 
   var: refToVar getVar;
-  wasVirtual: refToVar isSchema;
+  wasVirtual: refToVar isVirtual;
   makeDynamic: FALSE dynamic;
   pointee: VarRef @var.@data.get;
   pointeeVar: pointee getVar;
@@ -615,7 +615,7 @@ fixRef: [
   fixed.hostId @pointee.@hostId set
   fixed.varId  @pointee.@varId  set
 
-  wasVirtual [refToVar Schema makeStaticness @refToVar set] [
+  wasVirtual [refToVar Virtual makeStaticness @refToVar set] [
     makeDynamic [
       refToVar Dynamic makeStaticness @refToVar set
     ] when
@@ -759,10 +759,12 @@ fixOutputRefsRec: [
       stackEntryVar: currentFromStack getVar;
 
       stackEntryVar.data.getTag VarRef = [
-        stackPointee: VarRef @stackEntryVar.@data.get;
-        stackPointee.hostId currentChangesNodeIndex = [
-          fixed: currentFromStack fixRef getPointeeNoDerefIR;
-          fixed @unfinishedStack.pushBack
+        currentFromStack isSchema not [
+          stackPointee: VarRef @stackEntryVar.@data.get;
+          stackPointee.hostId currentChangesNodeIndex = [
+            fixed: currentFromStack fixRef getPointeeNoDerefIR;
+            fixed @unfinishedStack.pushBack
+          ] when
         ] when
       ] [
         stackEntryVar.data.getTag VarStruct = [

--- a/processor.mpl
+++ b/processor.mpl
@@ -105,6 +105,7 @@ NodeStateNew:         [0n8 dynamic];
 NodeStateNoOutput:    [1n8 dynamic]; #after calling NodeStateNew recursion with unknown output, node is uncompilable
 NodeStateHasOutput:   [2n8 dynamic]; #after merging "if" with output and without output, node can be compiled
 NodeStateCompiled:    [3n8 dynamic]; #node finished
+NodeStateFailed:      [4n8 dynamic]; #node finished
 
 NodeRecursionStateNo:       [0n8 dynamic];
 NodeRecursionStateFail:     [1n8 dynamic];
@@ -159,6 +160,8 @@ MatchingInfo: [{
   preInputs: RefToVar Array;
   captures: Capture Array;
   fieldCaptures: FieldCapture Array;
+  hasStackUnderflow: FALSE dynamic;
+  unfoundedNames: Int32 Cond HashTable; #nameInfos
 }];
 
 CFunctionSignature: [{
@@ -231,9 +234,11 @@ CodeNode: [{
   usedModulesTable:             Int32 UsedModuleInfo HashTable; # moduleID, hasUsedVars
   usedOrIncludedModulesTable:   Int32 Cond HashTable; # moduleID, hasUsedVars
 
-  refToVar:           RefToVar; #refToVar of this node
+  refToVar:           RefToVar; #refToVar of function with compiled node
   varNameInfo:        -1 dynamic; #variable name of imported function
   moduleId:           -1 dynamic;
+  indexArrayAddress:  0nx dynamic;
+  matchingInfoIndex:  -1 dynamic;
   exportDepth:        0 dynamic;
   namedFunctions:     String Int32 HashTable; # name -> node ID
   capturedVars:       RefToVar Array;
@@ -246,11 +251,21 @@ CodeNode: [{
   DIE: [];
 }];
 
+MatchingNode: [{
+  unknownMplType: IndexArray;
+  byMplType: Int32 IndexArray HashTable; #first input MPL type
+
+  compilerPositionInfo: CompilerPositionInfo;
+  entries: Int32;
+  tries: Int32;
+  size: Int32;
+}];
+
 Processor: [{
   options: ProcessorOptions;
 
   nodes:               CodeNode Owner Array;
-  matchingNodes:       Natx IndexArray HashTable;
+  matchingNodes:       Natx MatchingNode HashTable;
   recursiveNodesStack: Int32 Array;
   nameInfos:           NameInfo Array;
   modules:             String Int32 HashTable; # -1 no module, or Id of codeNode

--- a/processor.mpl
+++ b/processor.mpl
@@ -273,7 +273,7 @@ Processor: [{
   globalVarId:        0 dynamic;
   globalInitializer: -1 dynamic; # index of func for calling all initializers
   globalDestructibleVars: RefToVar Array;
-  processingExport: 0 dynamic;
+  exportDepth:            0 dynamic;
 
   stringNames: String String HashTable;        #for string constants
   typeNames: String Int32 HashTable;           #mplType->irAliasId

--- a/processor.mpl
+++ b/processor.mpl
@@ -173,70 +173,71 @@ UsedModuleInfo: [{
 }];
 
 CodeNode: [{
-  root: FALSE dynamic;
-  parent: 0 dynamic;
-  nodeCase: NodeCaseCode;
-  position: CompilerPositionInfo;
-  stack: RefToVar Array; # we must compile node without touching parent
-  minStackDepth: 0 dynamic;
-  program: Instruction Array;
-  aliases: String Array;
-  variables: Variable Owner Array; # as unique_ptr...
-  lastLambdaName: Int32;
-  nextRecLambdaId: -1 dynamic;
+  root:             FALSE dynamic;
+  parent:           0 dynamic;
+  nodeCase:         NodeCaseCode;
+  position:         CompilerPositionInfo;
+  stack:            RefToVar Array; # we must compile node without touching parent
+  minStackDepth:    0 dynamic;
+  program:          Instruction Array;
+  aliases:          String Array;
+  variables:        Variable Owner Array; # as unique_ptr...
+  lastLambdaName:   Int32;
+  nextRecLambdaId:  -1 dynamic;
 
-  nodeIsRecursive: FALSE dynamic;
+  nodeIsRecursive:    FALSE dynamic;
   nextLabelIsVirtual: FALSE dynamic;
-  nextLabelIsSchema: FALSE dynamic;
-  nextLabelIsConst: FALSE dynamic;
-  recursionState: NodeRecursionStateNo;
-  state: NodeStateNew;
-  struct: Struct;
-  irName: String;
-  header: String;
-  argTypes: String;
-  csignature: CFunctionSignature;
-  convention: String;
-  mplConvention: String;
-  signature: String;
-  nodeCompileOnce: FALSE dynamic;
-  empty: FALSE dynamic;
-  deleted: FALSE dynamic;
-  emptyDeclaration: FALSE dynamic;
-  uncompilable: FALSE dynamic;
-  variadic: FALSE dynamic;
+  nextLabelIsSchema:  FALSE dynamic;
+  nextLabelIsConst:   FALSE dynamic;
+  recursionState:     NodeRecursionStateNo;
+  state:              NodeStateNew;
+  struct:             Struct;
+  irName:             String;
+  header:             String;
+  argTypes:           String;
+  csignature:         CFunctionSignature;
+  convention:         String;
+  mplConvention:      String;
+  signature:          String;
+  nodeCompileOnce:    FALSE dynamic;
+  empty:              FALSE dynamic;
+  deleted:            FALSE dynamic;
+  emptyDeclaration:   FALSE dynamic;
+  uncompilable:       FALSE dynamic;
+  variadic:           FALSE dynamic;
 
-  countOfUCall: 0 dynamic;
-  declarationRefs: Cond Array;
+  countOfUCall:         0 dynamic;
+  declarationRefs:      Cond Array;
   buildingMatchingInfo: MatchingInfo;
-  matchingInfo: MatchingInfo;
-  outputs: Argument Array;
+  matchingInfo:         MatchingInfo;
+  outputs:              Argument Array;
 
   fromModuleNames:   NameWithOverloadAndRefToVar Array;
   labelNames:        NameWithOverloadAndRefToVar Array;
   captureNames:      NameWithOverloadAndRefToVar Array;
   fieldCaptureNames: NameWithOverloadAndRefToVar Array;
 
-  captureTable: RefToVar Cond HashTable;
+  captureTable:      RefToVar Cond HashTable;
   fieldCaptureTable: RefToVar Cond HashTable;
 
-  candidatesToDie: RefToVar Array;
+  candidatesToDie:     RefToVar Array;
   unprocessedAstNodes: IndexArray;
-  moduleName: String;
-  includedModules: Int32 Array; #ids in order
+  moduleName:          String;
+  includedModules:     Int32 Array; #ids in order
   directlyIncludedModulesTable: Int32 Cond HashTable; # dont include twice plz
-  includedModulesTable: Int32 UsedModuleInfo HashTable; # dont include twice plz
-  usedModulesTable: Int32 UsedModuleInfo HashTable; # moduleID, hasUsedVars
-  usedOrIncludedModulesTable: Int32 Cond HashTable; # moduleID, hasUsedVars
+  includedModulesTable:         Int32 UsedModuleInfo HashTable; # dont include twice plz
+  usedModulesTable:             Int32 UsedModuleInfo HashTable; # moduleID, hasUsedVars
+  usedOrIncludedModulesTable:   Int32 Cond HashTable; # moduleID, hasUsedVars
 
-  refToVar: RefToVar; #refToVar of this node
-  varNameInfo: -1 dynamic; #variable name of imported function
-  moduleId: -1 dynamic;
-  namedFunctions: String Int32 HashTable; # name -> node ID
-  capturedVars: RefToVar Array;
-  funcDbgIndex: -1 dynamic;
-  lastVarName: 0 dynamic;
-  lastBrLabelName: 0 dynamic;
+  refToVar:           RefToVar; #refToVar of this node
+  varNameInfo:        -1 dynamic; #variable name of imported function
+  moduleId:           -1 dynamic;
+  exportDepth:        0 dynamic;
+  namedFunctions:     String Int32 HashTable; # name -> node ID
+  capturedVars:       RefToVar Array;
+  funcDbgIndex:      -1 dynamic;
+  lastVarName:        0 dynamic;
+  lastBrLabelName:    0 dynamic;
   variableCountDelta: 0 dynamic;
 
   INIT: [];
@@ -246,12 +247,12 @@ CodeNode: [{
 Processor: [{
   options: ProcessorOptions;
 
-  nodes: CodeNode Owner Array;
-  matchingNodes: Natx IndexArray HashTable;
+  nodes:               CodeNode Owner Array;
+  matchingNodes:       Natx IndexArray HashTable;
   recursiveNodesStack: Int32 Array;
-  nameInfos: NameInfo Array;
-  modules: String Int32 HashTable; # -1 no module, or Id of codeNode
-  nameToId: String Int32 HashTable; # id of nameInfo from parser
+  nameInfos:           NameInfo Array;
+  modules:             String Int32 HashTable; # -1 no module, or Id of codeNode
+  nameToId:            String Int32 HashTable; # id of nameInfo from parser
 
   emptyNameInfo:               -1 dynamic;
   callNameInfo:                -1 dynamic;
@@ -268,50 +269,51 @@ Processor: [{
   failProcNameInfo:            -1 dynamic;
   conventionNameInfo:          -1 dynamic;
 
-  funcAliasCount:     0 dynamic;
-  globalVarCount:     0 dynamic;
-  globalVarId:        0 dynamic;
-  globalInitializer: -1 dynamic; # index of func for calling all initializers
+  funcAliasCount:         0 dynamic;
+  globalVarCount:         0 dynamic;
+  globalVarId:            0 dynamic;
+  globalInitializer:      -1 dynamic; # index of func for calling all initializers
   globalDestructibleVars: RefToVar Array;
   exportDepth:            0 dynamic;
 
   stringNames: String String HashTable;        #for string constants
-  typeNames: String Int32 HashTable;           #mplType->irAliasId
+  typeNames:   String Int32 HashTable;           #mplType->irAliasId
 
-  nameBuffer: String Array;
-  nameTable: StringView Int32 HashTable;       #strings->nameTag; strings from nameBuffer
+  nameBuffer:  String Array;
+  nameTable:   StringView Int32 HashTable;       #strings->nameTag; strings from nameBuffer
 
-  depthOfRecursion: 0 dynamic;
+  depthOfRecursion:    0 dynamic;
   maxDepthOfRecursion: 0 dynamic;
-  depthOfPre: 0 dynamic;
-  prolog: String Array;
+  depthOfPre:          0 dynamic;
+
+  prolog:              String Array;
 
   debugInfo: {
-    strings: String Array;
-    locationIds: IntTable;
-    lastId: 0 dynamic;
-    unit: -1 dynamic;
+    strings:          String Array;
+    locationIds:      IntTable;
+    lastId:           0 dynamic;
+    unit:             -1 dynamic;
     unitStringNumber: -1 dynamic;
-    cuStringNumber: -1 dynamic;
-    fileNameIds: Int32 Array;
-    typeIdToDbgId: IntTable;
-    globals: Int32 Array;
+    cuStringNumber:   -1 dynamic;
+    fileNameIds:      Int32 Array;
+    typeIdToDbgId:    IntTable;
+    globals:          Int32 Array;
   };
 
   lastStringId: 0 dynamic;
-  lastTypeId: 0 dynamic;
-  unitId: 0 dynamic; # number of compiling unit
+  lastTypeId:   0 dynamic;
+  unitId:       0 dynamic; # number of compiling unit
 
-  namedFunctions: String Int32 HashTable; # name -> node ID
+  namedFunctions:  String Int32 HashTable; # name -> node ID
   moduleFunctions: Int32 Array;
-  dtorFunctions: Int32 Array;
+  dtorFunctions:   Int32 Array;
 
-  varCount: 0 dynamic;
+  varCount:          0 dynamic;
   structureVarCount: 0 dynamic;
-  fieldVarCount: 0 dynamic;
-  nodeCount: 0 dynamic;
-  deletedNodeCount: 0 dynamic;
-  deletedVarCount: 0 dynamic;
+  fieldVarCount:     0 dynamic;
+  nodeCount:         0 dynamic;
+  deletedNodeCount:  0 dynamic;
+  deletedVarCount:   0 dynamic;
 
   usedFloatBuiltins: FALSE dynamic;
 

--- a/processor.mpl
+++ b/processor.mpl
@@ -276,7 +276,7 @@ Processor: [{
   globalDestructibleVars: RefToVar Array;
   exportDepth:            0 dynamic;
 
-  stringNames: String String HashTable;        #for string constants
+  stringNames: String RefToVar HashTable;        #for string constants
   typeNames:   String Int32 HashTable;           #mplType->irAliasId
 
   nameBuffer:  String Array;

--- a/processor.mpl
+++ b/processor.mpl
@@ -23,6 +23,7 @@ ProcessorOptions: [{
   logs:           FALSE dynamic;
   verboseIR:      FALSE dynamic;
   callTrace:      FALSE dynamic;
+  threadModel:    0 dynamic;
   linkerOptions:  String Array;
 }];
 

--- a/processor.mpl
+++ b/processor.mpl
@@ -22,6 +22,7 @@ ProcessorOptions: [{
   autoRecursion:  FALSE dynamic;
   logs:           FALSE dynamic;
   verboseIR:      FALSE dynamic;
+  callTrace:      FALSE dynamic;
   linkerOptions:  String Array;
 }];
 
@@ -205,6 +206,7 @@ CodeNode: [{
   emptyDeclaration:   FALSE dynamic;
   uncompilable:       FALSE dynamic;
   variadic:           FALSE dynamic;
+  hasNestedCall:      FALSE dynamic;
 
   countOfUCall:         0 dynamic;
   declarationRefs:      Cond Array;

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -223,7 +223,7 @@
     ("max depth of recursion=" processor.maxDepthOfRecursion) addLog
 
     processor.usedFloatBuiltins [createFloatBuiltins] when
-    processor.options.callTrace createCtors
+    processor.options.callTrace processor.options.threadModel 1 = and createCtors
     createDtors
     clearUnusedDebugInfo
     addAliasesForUsedNodes

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -223,7 +223,7 @@
     ("max depth of recursion=" processor.maxDepthOfRecursion) addLog
 
     processor.usedFloatBuiltins [createFloatBuiltins] when
-    createCtors
+    processor.options.callTrace createCtors
     createDtors
     clearUnusedDebugInfo
     addAliasesForUsedNodes

--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -69,6 +69,8 @@
   "" makeStringView addStrToProlog
   ("mainPath is \"" makeStringView processor.options.mainPath makeStringView "\"" makeStringView) addLog
 
+  processor.options.callTrace [createCallTraceData] when
+
   addLinkerOptionsDebugInfo
 
   processor.options.debug [

--- a/variable.mpl
+++ b/variable.mpl
@@ -127,30 +127,30 @@ CodeNodeInfo: [{
 Variable: [{
   VARIABLE: ();
 
-  mplNameId: -1 dynamic;
-  irNameId: -1 dynamic;
-  mplTypeId: -1 dynamic;
-  irTypeId: -1 dynamic;
-  dbgTypeId: -1 dynamic;
-  storageStaticness: Static;
-  staticness: Static;
-  global: FALSE dynamic;
-  temporary: TRUE dynamic;
-  usedInHeader: FALSE dynamic;
-  capturedAsMutable: FALSE dynamic;
-  capturedAsRealValue: FALSE dynamic;
-  tref: TRUE dynamic;
-  shadowReason: ShadowReasonNo;
-  globalId: -1 dynamic;
-  shadowBegin: RefToVar;
-  shadowEnd: RefToVar;
-  capturedHead: RefToVar;
-  capturedTail: RefToVar;
-  capturedPrev: RefToVar;
-  realValue: RefToVar;
+  mplNameId:                         -1 dynamic;
+  irNameId:                          -1 dynamic;
+  mplTypeId:                         -1 dynamic;
+  irTypeId:                          -1 dynamic;
+  dbgTypeId:                         -1 dynamic;
+  storageStaticness:                 Static;
+  staticness:                        Static;
+  global:                            FALSE dynamic;
+  temporary:                         TRUE dynamic;
+  usedInHeader:                      FALSE dynamic;
+  capturedAsMutable:                 FALSE dynamic;
+  capturedAsRealValue:               FALSE dynamic;
+  tref:                              TRUE dynamic;
+  shadowReason:                      ShadowReasonNo;
+  globalId:                          -1 dynamic;
+  shadowBegin:                       RefToVar;
+  shadowEnd:                         RefToVar;
+  capturedHead:                      RefToVar;
+  capturedTail:                      RefToVar;
+  capturedPrev:                      RefToVar;
+  realValue:                         RefToVar;
   globalDeclarationInstructionIndex: -1 dynamic;
-  allocationInstructionIndex: -1 dynamic;
-  getInstructionIndex: -1 dynamic;
+  allocationInstructionIndex:        -1 dynamic;
+  getInstructionIndex:               -1 dynamic;
 
   data: (
     Nat8             #VarInvalid

--- a/variable.mpl
+++ b/variable.mpl
@@ -946,6 +946,7 @@ getVirtualValue: [
   recursive
   var: refToVar getVar;
   result: String;
+
   var.data.getTag (
     VarStruct [
       "{" @result.cat
@@ -954,7 +955,9 @@ getVirtualValue: [
       struct.fields [
         pair:;
         pair.index 0 > ["," @result.cat] when
-        pair.value.refToVar getVirtualValue @result.cat
+        pair.value.refToVar isVirtualField not [
+          pair.value.refToVar getVirtualValue @result.cat
+        ] when
       ] each
       "}" @result.cat
     ]

--- a/variable.mpl
+++ b/variable.mpl
@@ -57,10 +57,12 @@ hash: ["REF_TO_VAR" has] [
   l:r:;;
   l.index r.index =
 ] pfunc;
+
 NameInfoEntry: [{
   refToVar: RefToVar;
   startPoint: -1 dynamic; # id of node
   nameCase: NameCaseInvalid;
+  index: -1 dynamic; # for NameCaseSelfMember
 }];
 
 Overload: [NameInfoEntry Array];


### PR DESCRIPTION
# Language changes

- ### Built-in string literals
    - Built-in string literals are stored in read-only memory and accessible for users only by pointers. Previously, string literal were leaving value-type on the stack, but semantically it was behaving like a reference
    - From now on, string literal leaves reference to a value of some internal type. It is impossible to have a value of this type, only a reference to it, same as with `codeRef`
    - `copy`, `storageSize` and `alignment` built-ins are no longer applicable to built-in string literals, for there is no more sense in that
- ### `getCallTrace` `( -- ( TraceElement ) )` built-in
    - Built-in returns list with information about call stack. Each element contains a file name, line number, and position in line. This built-in could be enabled by compiler option `-call_trace`
Example:
```
trace: getCallTrace;  
[
  trace.first trace.last is [
    FALSE
  ] [
    () LF printf
    (trace.last.name trace.last.line copy trace.last.column copy)
    "in %s at %i:%i" printf
    trace.last.prev trace.last addressToReference @trace.!last
    TRUE
  ] if
] loop
```
# Compiler changes
- ### `-call_trace x` compiler option
    - `-call_trace 0` no trace
    - `-call_trace 1` enables trace only for single-threaded application
    - `-call_trace 2` enables trace for any application for x86, thread-safe
- ### Improved error output
    - Compiler points out to a local variable, that was captured in a context that could potentially outlive that variable scope
```
# test.mpl
[
  x: 1;
  f: {} {} {} codeRef;
  [a: x;] !f
] call

->

test.mpl(5,7): error, [x], real function can not have real local capture
test.mpl(5,11): [!f], called from here
test.mpl(6,3): [call], called from here
```
- ### Improved function matching performance
# Bug fixes
- #### Fixed type of the argument that was declared as reference
```   
# test.mpl
{in: 0nx 0 addressToReference const;} () {} [
  printStack drop:;
] "load" exportFunction
```
Previous version:
```
> mplc -o test.ll test.mpl
stack:
depth=1
i32CC
```
Current version:
```
> mplc -o test.ll test.mpl
stack:
depth=1
i32C
```

- #### Fixed compilation fault for an overloaded function-member that uses a non-virtual variable of its own
```
# test.mpl
Obj: {
  fun: {
    CALL: [val];
    val:  42;
  };

  fun: {PRE:[FALSE]; CALL:[];};
};

[Obj.fun] call _:;
```
Previous version:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Wrong refToVar!
...
```
Current version:
```
> mplc -o test.ll test.mpl

```    

- #### Fixed visibility issues for overloads when member-function were called from `ASSIGN`, `CALL`, `DIE` or `INIT`:
```
#test.mpl

f: [];

g: {
  CALL: [f];

  f: {
    PRE:[0 same]; CALL:[do];
    do: [_:; f];
  };
};

0 g
```
Previous version:
```
> mplc -o test.ll test.mpl
test.mpl(8,14): error, [f], unknown name:f
test.mpl(7,25): [do], called from here
test.mpl(4,10): [f], called from here
test.mpl(12,3): [g], called from here
```
Current version:
```
> mplc -o test.ll test.mpl
```

- #### Fixed double call of non-virtual function from a recursive function 
```
# test.mpl
{} {} {} "F" importFunction

print: [
  recursive
  [
    a:;
    a 0 > [
      0 print
    ] [] if
  ] call
  F
];

() () {} [
  1 print
] "main" exportFunction
```
Previous version:
```
> mplc -ndebug -o test.ll test.mpl

# part of test.ll
define internal void @func.11.print(i32* %var.3) {
label1:
  call void @func.14.call(i32* %var.3)
  call void @F()
  call void @F()
  ret void
}
```
Current version:
```
> mplc -call_trace 0 -ndebug -o test.ll test.mpl

# part of test.ll
define internal void @func.11.print(i32* %var.3) {
label1:
  call void @func.14.call(i32* %var.3)
  call void @F()
  ret void
}
```

- #### Fixed crash on attempt to assign a virtual value that was indirectly marked `dynamic`
```
# test.mpl
 _: 0 [dynamic] call virtual;
```
Previous version:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Index out of range!
While compiling: at filename: ../test.mpl, token: _: nodeIndex: 2, line 2, column 1
```
Current version:
```
> mplc -o test.ll test.mpl
test.mpl(2,2): error, [_:], value for virtual label must be static
```

- #### Fixed crash on attempt to mark schema `dynamic`
```
# test.mpl
a: 0 schema;
a dynamic
```
Previous version:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Ref must be only Static or Dynamic!
at filename: test.mpl, token: dynamic, line: 2, column: 3
```
Current version:
```
> mplc -o test.ll test.mpl
test.mpl(3,3): error, [dynamic], can't dynamize schema
```

- #### Fixed crash on attempt to create an object with virtual field initialized by virtual string literal
```
# test.mpl
a: "" virtual;
x: {a: a virtual;};
```
Previous version:
```
> mplc -o test.ll test.mpl
ASSERTION FAILED!!!
Ref got from parent, but dont have shadow!
While compiling:
at filename: test.mpl, token: {, nodeIndex: 2, line: 3, column: 4
stack:
depth=0
Terminating...
```
Current version:
```
> mplc -o test.ll test.mpl
```

- #### Fixed endless loop on attempt to create an object with a field that contains schema of some virtual extrnal value
```
# test.mpl
virtual a: "";
{a schema b:;}
```
Previous version:
```
> mplc test.mpl -o test.ll 
(does not terminate)
```
Current version:
```
> mplc test.mpl -o test.ll
(terminates)
```

- #### Fixed incorrect matching resolution if it was based on result of calling an argument
```
# test.mpl
fact: [[] [0.AssertionFiled] uif]; #! condition

ok?: [_:; FALSE];
ok?: {PRE: [call TRUE]; CALL: [_:; TRUE];};

empty?: [[_:;] ok? ~];

empty? fact
42 empty? ~ fact _:;
```
Previous version:
```
> mplc -o test.ll test.mpl
test.mpl(1,13): error, [.AssertionFiled], not a combined
test.mpl(9,12): [fact], called from here
```
Current version:
```
> mplc -o test.ll test.mpl
```