### PR TITLE
Performance update

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -18,6 +18,7 @@ mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mp
  ../processor.mpl^
  ../processorImpl.mpl^
  ../processSubNodes.mpl^
+ ../schemas.mpl^
  ../staticCall.mpl^
  ../variable.mpl^
  ../sl/ascii.mpl^

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -18,6 +18,7 @@ mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll
  ../processor.mpl\
  ../processorImpl.mpl\
  ../processSubNodes.mpl\
+ ../schemas.mpl\
  ../staticCall.mpl\
  ../variable.mpl\
  ../sl/ascii.mpl\

--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -323,7 +323,7 @@ mplNumberBuiltinOp: [
 
           irarg: IRArgument;
           arg createDerefToRegister @irarg.@irNameId set
-          var.irTypeId @irarg.@irTypeId set
+          arg getMplSchema.irTypeId @irarg.@irTypeId set
           FALSE @irarg.@byRef set
           irarg @args.pushBack
 
@@ -429,10 +429,10 @@ mplNumberBuiltinOp: [
           irarg: IRArgument;
           FALSE @irarg.@byRef set
           arg1 createDerefToRegister @irarg.@irNameId set
-          var1.irTypeId @irarg.@irTypeId set
+          arg1 getMplSchema.irTypeId @irarg.@irTypeId set
           irarg @args.pushBack
           arg2 createDerefToRegister @irarg.@irNameId set
-          var2.irTypeId @irarg.@irTypeId set
+          arg2 getMplSchema.irTypeId @irarg.@irTypeId set
           irarg @args.pushBack
 
           result args String tag VarReal32 = ["@llvm.pow.f32" makeStringView] ["@llvm.pow.f64" makeStringView] if createCallIR retName:;
@@ -915,7 +915,7 @@ parseSignature: [
       @processor.@prolog.last move @instruction set
       @processor.@prolog.popBack
       TRUE @refToVar.@mutable set
-      oldIrNameId var.irNameId var.irTypeId createGlobalAliasIR
+      oldIrNameId var.irNameId refToVar getMplSchema.irTypeId createGlobalAliasIR
       oldInstructionIndex @var.@globalDeclarationInstructionIndex set
 
       nameInfo: name findNameInfo;

--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1811,9 +1811,7 @@ copyOneVarWith: [
 
   src.mutable @dst.@mutable set
   dstVar: dst getVar;
-  srcVar.irTypeId  @dstVar.@irTypeId set
-  srcVar.mplTypeId @dstVar.@mplTypeId set
-  srcVar.dbgTypeId @dstVar.@dbgTypeId set
+  srcVar.mplSchemaId @dstVar.@mplSchemaId set
 
   dst
 ];
@@ -2792,7 +2790,7 @@ concreteMatchingNode: [
 
     byMplType: info.@byMplType;
 
-    key: 0 node.matchingInfo.inputs.at.refToVar getVar.mplTypeId copy;
+    key: 0 node.matchingInfo.inputs.at.refToVar getVar.mplSchemaId copy;
 
     fr: key @info.@byMplType.find;
     fr.success [

--- a/debugWriter.mpl
+++ b/debugWriter.mpl
@@ -110,9 +110,9 @@ getPointerTypeDebugDeclaration: [
   refToVar:;
   compileOnce
   var: refToVar getVar;
-  fr: var.mplTypeId @processor.@debugInfo.@typeIdToDbgId.find;
-  [fr.success copy] "Pointee has no type debug info!" assert
-  "DW_TAG_pointer_type" makeStringView fr.value processor.options.pointerSize 0ix cast 0 cast addDerivedTypeInfo
+  debugDeclarationIndex: refToVar getMplSchema.dbgTypeDeclarationId copy;
+  [debugDeclarationIndex -1 = ~] "Pointee has no type debug info!" assert
+  "DW_TAG_pointer_type" makeStringView debugDeclarationIndex processor.options.pointerSize 0ix cast 0 cast addDerivedTypeInfo
 ];
 
 addLinkedLib: [
@@ -128,8 +128,8 @@ addMemberInfo: [
   field:;
   offset:;
 
-  fr: field.refToVar getVar.mplTypeId @processor.@debugInfo.@typeIdToDbgId.find;
-  [fr.success copy] "Field has not debug info about type!" assert
+  debugDeclarationIndex: field.refToVar getMplSchema.dbgTypeDeclarationId copy;
+  [debugDeclarationIndex -1 = ~] "Field has not debug info about type!" assert
 
   fsize: field.refToVar getStorageSize 0ix cast 0 cast;
   falignment: field.refToVar getAlignment 0ix cast 0 cast;
@@ -143,11 +143,11 @@ addMemberInfo: [
   name "" = [
     ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"f" fieldNumber "\", scope: !" currentNode.funcDbgIndex
       ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
-      ", line: " currentNode.position.line ", baseType: !" fr.value ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
+      ", line: " currentNode.position.line ", baseType: !" debugDeclarationIndex ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
   ] [
     ("!" index " = !DIDerivedType(tag: DW_TAG_member, name: \"" name "\", scope: !" currentNode.funcDbgIndex
       ", file: !" currentNode.position.fileNumber processor.debugInfo.fileNameIds.at
-      ", line: " currentNode.position.line ", baseType: !" fr.value ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
+      ", line: " currentNode.position.line ", baseType: !" debugDeclarationIndex ", size: " fsize 8 * ", offset: " offset 8 * ")") assembleString
   ] if
 
   @processor.@debugInfo.@strings.pushBack
@@ -231,9 +231,8 @@ addVariableDebugInfo: [
   copy nameInfo:;
 
   refToVar isVirtualType not [
-    fr: refToVar getVar.mplTypeId @processor.@debugInfo.@typeIdToDbgId.find;
-    [fr.success copy] "There is no debug declaration for this type!" assert
-    debugDeclarationIndex: fr.value copy;
+    debugDeclarationIndex: refToVar getMplSchema.dbgTypeDeclarationId copy;
+    [debugDeclarationIndex -1 = ~] "There is no debug declaration for this type!" assert
     index: processor.debugInfo.lastId copy;
     processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set
     ("!" index " = !DILocalVariable(name: \"" nameInfo processor.nameInfos.at.name "\", scope: !" currentNode.funcDbgIndex
@@ -252,9 +251,8 @@ addGlobalVariableDebugInfo: [
   copy nameInfo:;
 
   refToVar isVirtualType not [
-    fr: refToVar getVar.mplTypeId @processor.@debugInfo.@typeIdToDbgId.find;
-    [fr.success copy] "There is no debug declaration for this type!" assert
-    debugDeclarationIndex: fr.value copy;
+    debugDeclarationIndex: refToVar getMplSchema.dbgTypeDeclarationId copy;
+    [debugDeclarationIndex -1 = ~] "There is no debug declaration for this type!" assert
 
     index: processor.debugInfo.lastId copy;
     processor.debugInfo.lastId 1 + @processor.@debugInfo.@lastId set

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -487,7 +487,7 @@ tryMatchNode: [
     result: -1 dynamic;
 
     getStackDepth 0 > [
-      byType: 0 dynamic getStackEntry getVar.mplTypeId fr.value.byMplType.find;
+      byType: 0 dynamic getStackEntry getVar.mplSchemaId fr.value.byMplType.find;
 
       byType.success [
         byType.value findInIndexArray @result set
@@ -1161,7 +1161,7 @@ makeCallInstructionWith: [
       ] [
         arg: IRArgument;
         currentInput getVar.irNameId @arg.@irNameId set
-        currentInput getVar.irTypeId @arg.@irTypeId set
+        currentInput getMplSchema.irTypeId @arg.@irTypeId set
         currentInputArgCase ArgRef = [currentInputArgCase ArgRefDeref =] || @arg.@byRef set
         currentInputArgCase ArgCopy = [currentInput createDerefToRegister @arg.@irNameId set] when
 
@@ -1191,7 +1191,7 @@ makeCallInstructionWith: [
         ] [
           arg: IRArgument;
           refToVar getVar.irNameId @arg.@irNameId set
-          refToVar getVar.irTypeId @arg.@irTypeId set
+          refToVar getMplSchema.irTypeId @arg.@irTypeId set
           TRUE @arg.@byRef set
 
           arg @argList.pushBack
@@ -1215,7 +1215,7 @@ makeCallInstructionWith: [
 
           arg: IRArgument;
           refToVar getVar.irNameId @arg.@irNameId set
-          refToVar getVar.irTypeId @arg.@irTypeId set
+          refToVar getMplSchema.irTypeId @arg.@irTypeId set
           TRUE @arg.@byRef set
           TRUE @arg.@byRef set
 

--- a/processor.mpl
+++ b/processor.mpl
@@ -1,6 +1,7 @@
 "processor" module
 "control" includeModule
 "astNodeType" includeModule
+"schemas" includeModule
 
 CompilerPositionInfo: [{
   column:     -1 dynamic;
@@ -297,6 +298,9 @@ Processor: [{
   stringNames: String RefToVar HashTable;        #for string constants
   typeNames:   String Int32 HashTable;           #mplType->irAliasId
 
+  schemaBuffer: VariableSchema Array;
+  schemaTable: VariableSchema Int32 HashTable;
+
   nameBuffer:  String Array;
   nameTable:   StringView Int32 HashTable;       #strings->nameTag; strings from nameBuffer
 
@@ -314,7 +318,6 @@ Processor: [{
     unitStringNumber: -1 dynamic;
     cuStringNumber:   -1 dynamic;
     fileNameIds:      Int32 Array;
-    typeIdToDbgId:    IntTable;
     globals:          Int32 Array;
   };
 

--- a/schemas.mpl
+++ b/schemas.mpl
@@ -1,0 +1,327 @@
+"schemas" module
+
+"control" includeModule
+"String" includeModule
+
+makeVariableSchema: [
+  var:;
+  varSchema: VariableSchema;
+  var.data.getTag (
+    VarImport [
+      VariableSchemaTags.FUNCTION_SCHEMA @varSchema.@data.setTag
+      functionSchema: VariableSchemaTags.FUNCTION_SCHEMA @varSchema.@data.get;
+      functionId: VarImport var.data.get;
+      node: functionId processor.nodes.at.get;
+      signature: node.csignature;
+      signature.inputs.getSize @functionSchema.@inputSchemaIds.resize
+      signature.inputs [
+        pair:;
+        pair.value getVar.mplSchemaId copy pair.index @functionSchema.@inputSchemaIds !
+      ] each
+
+      signature.outputs.getSize @functionSchema.@outputSchemaIds.resize
+      signature.outputs [
+        pair:;
+        pair.value getVar.mplSchemaId copy pair.index @functionSchema.@outputSchemaIds !
+      ] each
+
+      signature.variadic copy @functionSchema.!variadic
+      signature.convention copy @functionSchema.!convention
+    ]
+    VarRef [
+      VariableSchemaTags.REF_SCHEMA @varSchema.@data.setTag
+      refSchema: VariableSchemaTags.REF_SCHEMA @varSchema.@data.get;
+      ref: VarRef var.data.get;
+      pointee: ref getVar;
+      ref.mutable copy @refSchema.!mutable
+      pointee.mplSchemaId copy @refSchema.!pointeeSchemaId
+    ]
+    VarStruct [
+      VariableSchemaTags.STRUCT_SCHEMA @varSchema.@data.setTag
+      structSchema: VariableSchemaTags.STRUCT_SCHEMA @varSchema.@data.get;
+      struct: VarStruct var.data.get.get;
+      struct.fields.getSize @structSchema.@data.resize
+      struct.fields [
+        pair:;
+        field: pair.value;
+        fieldSchema: FieldSchema;
+        field.refToVar getVar.mplSchemaId @fieldSchema.@valueSchemaId set
+        field.nameInfo copy @fieldSchema.!nameInfo
+        @fieldSchema pair.index @structSchema.@data @ set
+      ] each
+    ]
+    [
+      VariableSchemaTags.BUILTIN_TYPE_SCHEMA @varSchema.@data.setTag
+      builtinTypeSchema: VariableSchemaTags.BUILTIN_TYPE_SCHEMA @varSchema.@data.get;
+      var.data.getTag @builtinTypeSchema.@tag set
+    ]
+  ) case
+
+  refToVar isVirtual [
+    schemaId: varSchema getVariableSchemaId;
+    VariableSchemaTags.VIRTUAL_VALUE_SCHEMA @varSchema.@data.setTag
+    virtualValueSchema: VariableSchemaTags.VIRTUAL_VALUE_SCHEMA @varSchema.@data.get;
+    schemaId copy @virtualValueSchema.!schemaId
+    refToVar getVirtualValue @virtualValueSchema.!vitrualValue
+  ] when
+
+  @varSchema
+];
+
+getVariableSchemaId: [
+  varSchemaIsMoved: isMoved;
+  varSchema:;
+  findResult: varSchema processor.schemaTable.find;
+  findResult.success [
+    findResult.value copy
+  ] [
+    schemaId: processor.schemaBuffer.getSize;
+    varSchema schemaId @processor.@schemaTable.insert
+    @varSchema varSchemaIsMoved moveIf @processor.@schemaBuffer.pushBack
+    schemaId copy
+  ] if
+];
+
+VariableSchema: [{
+  VARIABLE_SCHEMA: ();
+  irTypeId: -1;
+  dbgTypeId: -1;
+  dbgTypeDeclarationId: -1;
+  data: (
+    BuiltinTypeSchema
+    FunctionSchema
+    RefSchema
+    StructSchema
+    VirtualValueSchema
+  ) Variant;
+}];
+
+VariableSchemaTags: (
+  "BUILTIN_TYPE_SCHEMA"
+  "FUNCTION_SCHEMA"
+  "REF_SCHEMA"
+  "STRUCT_SCHEMA"
+  "VIRTUAL_VALUE_SCHEMA"
+) Int32 enum;
+
+BuiltinTypeSchema: [{
+  BUILTIN_TYPE_SCHEMA: ();
+  tag: Int32;
+}];
+
+RefSchema: [{
+  REF_SCHEMA: ();
+  pointeeSchemaId: Int32;
+  mutable: Cond;
+}];
+
+FieldSchema: [{
+  FIELD_SCHEMA: ();
+  nameInfo: Int32;
+  valueSchemaId: Int32;
+}];
+
+FunctionSchema: [{
+  FUNCTION_SCHEMA: ();
+  inputSchemaIds: Int32 Array;
+  outputSchemaIds: Int32 Array;
+  convention: String;
+  variadic: Cond;
+}];
+
+VirtualValueSchema: [{
+  VIRTUAL_VALUE_SCHEMA: ();
+  schemaId: Int32;
+  vitrualValue: String;
+}];
+
+StructSchema: [{
+  STRUCT_SCHEMA: ();
+  data: FieldSchema Array;
+}];
+
+twoWith: [
+  predicate:;
+  x:y:;;
+  @x predicate
+  @y predicate and
+];
+
+=: [["VARIABLE_SCHEMA" has] twoWith] [
+  x: .data;
+  y: .data;
+  tag: x.getTag;
+  tag y.getTag = [
+    tag (
+      VariableSchemaTags fieldCount [
+        i copy i copy [
+          tag:;
+          tag x.get
+          tag y.get =
+        ] bind
+      ] times
+      [
+        [FALSE] "invalid tag in VariableSchema" assert
+        FALSE
+      ]
+    ) case
+  ] [
+    FALSE
+  ] if
+] pfunc;
+
+=: [["REF_SCHEMA" has] twoWith] [
+  x:y:;;
+  x.pointeeSchemaId y.pointeeSchemaId = [x.mutable y.mutable =] &&
+] pfunc;
+
+=: [["STRUCT_SCHEMA" has] twoWith] [
+  x: .data;
+  y: .data;
+  result: x.getSize y.getSize =;
+  fieldIndex0: 0;
+  [result [fieldIndex0 x.getSize <] &&] [
+    fieldIndex0 x @ fieldIndex0 y @ = !result
+    fieldIndex0 1 + !fieldIndex0
+  ] while
+
+  result
+] pfunc;
+
+=: [["FIELD_SCHEMA" has] twoWith] [
+  x:y:;;
+  x.nameInfo y.nameInfo = [x.valueSchemaId y.valueSchemaId =] &&
+] pfunc;
+
+=: [["FUNCTION_SCHEMA" has] twoWith] [
+  x:y:;;
+  result: TRUE;
+  (
+    [result]
+    [x.convention y.convention = !result]
+    [x.variadic y.variadic = !result]
+    [
+      x.inputSchemaIds.getSize
+      y.inputSchemaIds.getSize = !result
+    ]
+    [
+      x.outputSchemaIds.getSize
+      y.outputSchemaIds.getSize = !result
+    ]
+    [
+      inputIndex: 0;
+      [result [inputIndex x.inputSchemaIds.getSize <] &&] [
+        inputIndex x.inputSchemaIds @
+        inputIndex y.inputSchemaIds @ = !result
+        inputIndex 1 + !inputIndex
+      ] while
+    ]
+    [
+      outputIndex: 0;
+      [result [outputIndex x.outputSchemaIds.getSize <] &&] [
+        outputIndex x.outputSchemaIds @
+        outputIndex y.outputSchemaIds @ = !result
+        outputIndex 1 + !outputIndex
+      ] while
+    ]
+  ) sequence
+
+  result
+] pfunc;
+
+=: [["VIRTUAL_VALUE_SCHEMA" has] twoWith] [
+  x:y:;;
+  x.schemaId y.schemaId = [x.vitrualValue y.vitrualValue =] &&
+] pfunc;
+
+=: [["BUILTIN_TYPE_SCHEMA" has] twoWith] [
+  x:;
+  y:;
+  x.tag y.tag =
+] pfunc;
+
+hash: ["VARIABLE_SCHEMA" has] [
+  variableSchema: .data;
+  seed: 0n32;
+  @seed variableSchema.getTag hashCombine
+  variableSchema [value:; @seed value hashSchema] visit
+  @seed
+] pfunc;
+
+hashSchema: ["FIELD_SCHEMA" has] [
+  fieldSchema:;
+  seed:;
+  @seed fieldSchema.nameInfo hashCombine
+  @seed fieldSchema.valueSchemaId hashCombine
+] pfunc;
+
+hashSchema: ["REF_SCHEMA" has] [
+  refSchema:;
+  seed:;
+  @seed refSchema.pointeeSchemaId hashCombine
+  @seed refSchema.mutable hashCombine
+] pfunc;
+
+hashSchema: ["FUNCTION_SCHEMA" has] [
+  functionSchema:;
+  seed:;
+  functionSchema.inputSchemaIds [
+    value: .value;
+    @seed value hashCombine
+  ] each
+
+  functionSchema.outputSchemaIds [
+    value: .value;
+    @seed value hashCombine
+  ] each
+
+  @seed functionSchema.convention hash hashCombine
+  @seed functionSchema.variadic hashCombine
+] pfunc;
+
+hashSchema: ["VIRTUAL_VALUE_SCHEMA" has] [
+  virtualValueSchema:;
+  seed:;
+  @seed virtualValueSchema.schemaId hashCombine
+  @seed virtualValueSchema.vitrualValue hash hashCombine
+] pfunc;
+
+hashSchema: ["STRUCT_SCHEMA" has] [
+  structSchema: .data;
+  seed:;
+  structSchema [
+    value: .value;
+    @seed value hashSchema
+  ] each
+] pfunc;
+
+hashSchema: ["BUILTIN_TYPE_SCHEMA" has] [.tag Nat32 cast hashCombine] pfunc;
+
+visit: [
+  variant:callback:;;
+  variant.getTag (
+    variant.typeList fieldCount [
+      i copy i copy [@variant.get callback] bind
+    ] times
+
+    ["invalid tag in variant" failProc]
+  ) case
+];
+
+hashCombine: [
+  seed:value:;;
+  value hashValue 0x9e3779b9n32 + seed 6n32 lshift + seed 2n32 rshift + @seed set
+];
+
+hashValue: [Int8 same] [Nat32 cast] pfunc;
+hashValue: [Int16 same] [Nat32 cast] pfunc;
+hashValue: [Int32 same] [Nat32 cast] pfunc;
+hashValue: [Int64 same] [Nat64 cast Nat32 cast] pfunc;
+hashValue: [IntX same] [Nat64 cast Nat32 cast] pfunc;
+hashValue: [Nat8 same] [Nat32 cast] pfunc;
+hashValue: [Nat16 same] [Nat32 cast] pfunc;
+hashValue: [Nat32 same] [Nat32 cast] pfunc;
+hashValue: [Nat32 same] [Nat32 cast] pfunc;
+hashValue: [Nat64 same] [Nat32 cast] pfunc;
+hashValue: [NatX same] [Nat32 cast] pfunc;
+hashValue: [Cond same] [[1n32] [0n32] if] pfunc;


### PR DESCRIPTION
Changed representation for object schemas: used structures instead of strings. Removed redundant IR type and debug type strings building: compiler builds these strings only once for each distinct schema. Removed one hashtable used for linking schema to debug type declaration string: this information stored in schema object now.

| Self build             | debug, seconds | release, seconds|
| -------------------|:------------------:|:----------------: | 
| without interning| 146.50                | 27.61                |
| with interning      | 65.95                 | 24.34                 |