### PR TITLE
Performance update

### DIFF
--- a/build/compile.bat
+++ b/build/compile.bat
@@ -2,7 +2,7 @@
 
 FOR /F "tokens=*" %%v IN ('git log --date^=format:%%y%%m%%d --format^=%%cd -1') DO SET SOURCE_VERSION=%%v
 
-mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -D DEBUG=TRUE -ndebug -o mplc.ll^
+mplc.exe -D COMPILER_SOURCE_VERSION=%SOURCE_VERSION% -ndebug -o mplc.ll^
  ../astNodeType.mpl^
  ../astOptimizers.mpl^
  ../builtinImpl.mpl^

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -2,7 +2,7 @@
 
 SOURCE_VERSION=$(git log --date=format:%y%m%d --format=%cd -1)
 
-mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -D DEBUG=TRUE -ndebug -o mplc.ll\
+mplc -D COMPILER_SOURCE_VERSION=$SOURCE_VERSION -ndebug -o mplc.ll\
  ../astNodeType.mpl\
  ../astOptimizers.mpl\
  ../builtinImpl.mpl\


### PR DESCRIPTION
Disabling asserts makes compiler 2x faster

| Self build           | release, seconds |
| ------------------|:-----------------: | 
| with asserts        | 51.26                  |
| without asserts  | 23.57                  |