### PR TITLE
Bug fix

### DIFF
--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -1076,7 +1076,7 @@ processListNode: [
     compilable [
       FALSE dynamic @processorResult.@success set
 
-      processor.depthOfPre 0 = [
+      processor.depthOfPre 0 = [processorResult.passErrorThroughPRE copy] || [
         message toString @processorResult.@errorInfo.@message set
         nodeIndex: indexOfNode copy;
 
@@ -3776,13 +3776,13 @@ nodeHasCode: [
   maxDepthOfPre:       64;
 
   processor.depthOfRecursion maxDepthOfRecursion > [
+    TRUE dynamic @processorResult.@passErrorThroughPRE set
     ("max depth of recursion (" maxDepthOfRecursion ") exceeded") assembleString compilerError
-    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
 
   processor.depthOfPre maxDepthOfPre > [
+    TRUE dynamic @processorResult.@passErrorThroughPRE set
     ("max depth of PRE recursion (" maxDepthOfPre ") exceeded") assembleString compilerError
-    TRUE dynamic @processorResult.@maxDepthExceeded set
   ] when
   
   #add to match table

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -7,7 +7,7 @@ clearProcessorResult: [
   copy cachedGlobalErrorInfoSize:;
   TRUE dynamic              @processorResult.@success set
   FALSE dynamic             @processorResult.@findModuleFail set
-  FALSE dynamic             @processorResult.@maxDepthExceeded set
+  FALSE dynamic             @processorResult.@passErrorThroughPRE set
   String                    @processorResult.@program set
   ProcessorErrorInfo        @processorResult.@errorInfo set
   cachedGlobalErrorInfoSize 0 < not [
@@ -1381,7 +1381,7 @@ processCallByNode: [
 
     oldGlobalErrorCount @processorResult.@globalErrorInfo.shrink
     oldSuccess [
-      processorResult.maxDepthExceeded not [-1 clearProcessorResult] when
+      processorResult.passErrorThroughPRE not [-1 clearProcessorResult] when
     ] [
       [FALSE] "Has compilerError before trying compiling pre!" assert
     ] if
@@ -1406,6 +1406,7 @@ processCallByNode: [
       [top staticnessOfVar Weak < not] && [
         VarCond top getVar.data.get copy
       ] [
+        TRUE dynamic @processorResult.@passErrorThroughPRE set
         "PRE code must fail or return static Cond" compilerError
         FALSE dynamic
       ] if
@@ -1809,6 +1810,7 @@ processLoop: [
 
     iterationNumber 1 + @iterationNumber set
     iterationNumber maxLoopLength > [
+      TRUE @processorResult.!passErrorThroughPRE
       "static loop length too big, did you forget to add \"dynamic\"?" makeStringView compilerError
     ] when
 

--- a/processor.mpl
+++ b/processor.mpl
@@ -37,7 +37,7 @@ ProcessorErrorInfo: [{
 ProcessorResult: [{
   success: TRUE dynamic;
   findModuleFail: FALSE dynamic;
-  maxDepthExceeded: FALSE dynamic;
+  passErrorThroughPRE: FALSE dynamic;
   program: String;
   errorInfo: ProcessorErrorInfo;
   globalErrorInfo: ProcessorErrorInfo Array;


### PR DESCRIPTION
Resolves #9.
This PR forces errors to propagate through PRE
Error list:
- Maximum static recursion depth exceeded
- Maximum static loop iteration count exceeded
- PRE neither failed nor returned static Cond

These errors show either a mistake in PRE code or indicate that one of the limits in the compiler is too low.