### PR TITLE
Add command-line options for setting specific limits

### DIFF
--- a/codeNode.mpl
+++ b/codeNode.mpl
@@ -3772,17 +3772,14 @@ nodeHasCode: [
     processor.depthOfRecursion @processor.@maxDepthOfRecursion set
   ] when
 
-  maxDepthOfRecursion: 256;
-  maxDepthOfPre:       64;
-
-  processor.depthOfRecursion maxDepthOfRecursion > [
+  processor.depthOfRecursion processor.options.recursionDepthLimit > [
     TRUE dynamic @processorResult.@passErrorThroughPRE set
-    ("max depth of recursion (" maxDepthOfRecursion ") exceeded") assembleString compilerError
+    ("Recursion depth limit (" processor.options.recursionDepthLimit ") exceeded. It can be changed using -recursion_depth_limit option.") assembleString compilerError
   ] when
 
-  processor.depthOfPre maxDepthOfPre > [
+  processor.depthOfPre processor.options.preRecursionDepthLimit > [
     TRUE dynamic @processorResult.@passErrorThroughPRE set
-    ("max depth of PRE recursion (" maxDepthOfPre ") exceeded") assembleString compilerError
+    ("PRE recursion depth limit (" processor.options.preRecursionDepthLimit  ") exceeded. It can be changed using -pre_recursion_depth_limit option.") assembleString compilerError
   ] when
   
   #add to match table

--- a/main.mpl
+++ b/main.mpl
@@ -98,9 +98,8 @@ parseIntegerOption: [
       ] when
     ]
     [
-      tenPower: 1;
-      codepointIndex: codepoints.getSize 1 -;
-      [result.error "" = [codepointIndex 0 < ~] &&] [
+      codepointIndex: 0;
+      [result.error "" = [codepointIndex codepoints.getSize <] &&] [
         codepoint: codepointIndex codepoints @;
         asciiCode: codepoint.dataBegin Nat32 cast;
         asciiCode (
@@ -108,12 +107,11 @@ parseIntegerOption: [
           [code:; code ascii.zero = [codepointIndex 0 =] && [codepoints.getSize 1 >] &&] ["value has leading zeros" toString @result.!error]
           [
             digit: asciiCode ascii.zero - Int32 cast;
-            digit tenPower * result.value + @result.@value set
-            10 tenPower * @tenPower set
+            result.value 10 * digit + @result.@value set
           ]
         ) cond
 
-        codepointIndex 1 - !codepointIndex
+        codepointIndex 1 + !codepointIndex
       ] while
     ]
   ) sequence

--- a/main.mpl
+++ b/main.mpl
@@ -21,12 +21,12 @@ printInfo: [
   "  -logs                               Value of \"HAS_LOGS\" constant in code turn to TRUE" print LF print
   "  -ndebug                             Disable debug info; value of \"DEBUG\" constant in code turn to FALSE" print LF print
   "  -o <file>                           Write output to <file>, default output file is \"mpl.ll\"" print LF print
+  "  -pre_recursion_depth_limit <number> Set PRE recursion depth limit, default value is " print DEFAULT_PRE_RECURSION_DEPTH_LIMIT print LF print
+  "  -recursion_depth_limit <number>     Set recursion depth limit, default value is " print DEFAULT_RECURSION_DEPTH_LIMIT print LF print
+  "  -static_loop_length_limit <number>  Set static loop length limit, default value is " print DEFAULT_STATIC_LOOP_LENGTH_LIMIT print LF print
   "  -statlit                            Number literals are static constants, which are used in analysis; default mode is static literals" print LF print
   "  -verbose_ir                         Print information about current token in IR" print LF print
   "  -version                            Print compiler version while compiling" print LF print
-  "  -recursion_depth_limit <number>     Set recursion depth limit, default value is " print DEFAULT_RECURSION_DEPTH_LIMIT print LF print
-  "  -pre_recursion_depth_limit <number> Set PRE recursion depth limit, default value is " print DEFAULT_PRE_RECURSION_DEPTH_LIMIT print LF print
-  "  -static_loop_length_limit <number>  Set static loop length limit, default value is " print DEFAULT_STATIC_LOOP_LENGTH_LIMIT print LF print
   FALSE @success set
 ];
 

--- a/main.mpl
+++ b/main.mpl
@@ -10,20 +10,23 @@
 printInfo: [
   "USAGE: mplc.exe [options] <inputs>" print LF print
   "OPTIONS:" print LF print
-  "  -32bits             Set 32-bit mode, default mode is 64-bit" print LF print
-  "  -64bits             Set 64-bit mode, default mode is 64-bit" print LF print
-  "  -D <name[ =value]>  Define global name with value, default value is ()" print LF print
-  "  -array_checks 0|1   Turn off/on array index checks, by default it is on in debug mode and off in release mode" print LF print
-  "  -auto_recursion     Make all code block recursive-by-default" print LF print
-  "  -call_trace         Generate information about call trace" print LF print
-  "  -dynalit            Number literals are dynamic constants, which are not used in analysis; default mode is static literals" print LF print
-  "  -linker_option      Add linker option for LLVM" print LF print
-  "  -logs               Value of \"HAS_LOGS\" constant in code turn to TRUE" print LF print
-  "  -ndebug             Disable debug info; value of \"DEBUG\" constant in code turn to FALSE" print LF print
-  "  -o <file>           Write output to <file>, default output file is \"mpl.ll\"" print LF print
-  "  -statlit            Number literals are static constants, which are used in analysis; default mode is static literals" print LF print
-  "  -verbose_ir         Print information about current token in IR" print LF print
-  "  -version            Print compiler version while compiling" print LF print
+  "  -32bits                             Set 32-bit mode, default mode is 64-bit" print LF print
+  "  -64bits                             Set 64-bit mode, default mode is 64-bit" print LF print
+  "  -D <name[ =value]>                  Define global name with value, default value is ()" print LF print
+  "  -array_checks 0|1                   Turn off/on array index checks, by default it is on in debug mode and off in release mode" print LF print
+  "  -auto_recursion                     Make all code block recursive-by-default" print LF print
+  "  -call_trace                         Generate information about call trace" print LF print
+  "  -dynalit                            Number literals are dynamic constants, which are not used in analysis; default mode is static literals" print LF print
+  "  -linker_option                      Add linker option for LLVM" print LF print
+  "  -logs                               Value of \"HAS_LOGS\" constant in code turn to TRUE" print LF print
+  "  -ndebug                             Disable debug info; value of \"DEBUG\" constant in code turn to FALSE" print LF print
+  "  -o <file>                           Write output to <file>, default output file is \"mpl.ll\"" print LF print
+  "  -statlit                            Number literals are static constants, which are used in analysis; default mode is static literals" print LF print
+  "  -verbose_ir                         Print information about current token in IR" print LF print
+  "  -version                            Print compiler version while compiling" print LF print
+  "  -recursion_depth_limit <number>     Set recursion depth limit, default value is " print DEFAULT_RECURSION_DEPTH_LIMIT print LF print
+  "  -pre_recursion_depth_limit <number> Set PRE recursion depth limit, default value is " print DEFAULT_PRE_RECURSION_DEPTH_LIMIT print LF print
+  "  -static_loop_length_limit <number>  Set static loop length limit, default value is " print DEFAULT_STATIC_LOOP_LENGTH_LIMIT print LF print
   FALSE @success set
 ];
 
@@ -73,6 +76,62 @@ createDefinition: [
   ] if
 ];
 
+parseIntegerOption: [
+  text:;
+  result: {
+    error: "" toString;
+    value: 0;
+  };
+
+  (
+    [result.error "" =]
+    [
+      splitResult: text makeStringView.split;
+      splitResult.success ~ [
+        "value is not value UTF-8 sequence" toString @result.!error
+      ] when
+    ]
+    [
+      codepoints: splitResult.chars;
+      codepoints.getSize 0 = [
+        "value is empty" toString @result.!error
+      ] when
+    ]
+    [
+      tenPower: 1;
+      codepointIndex: codepoints.getSize 1 -;
+      [result.error "" = [codepointIndex 0 < ~] &&] [
+        codepoint: codepointIndex codepoints @;
+        asciiCode: codepoint.dataBegin Nat32 cast;
+        asciiCode (
+          [code:; asciiCode ascii.zero < [asciiCode ascii.nine >] ||] ["value has non-digit character" toString @result.!error]
+          [code:; code ascii.zero = [codepointIndex 0 =] && [codepoints.getSize 1 >] &&] ["value has leading zeros" toString @result.!error]
+          [
+            digit: asciiCode ascii.zero - Int32 cast;
+            digit tenPower * result.value + @result.@value set
+            10 tenPower * @tenPower set
+          ]
+        ) cond
+
+        codepointIndex 1 - !codepointIndex
+      ] while
+    ]
+  ) sequence
+
+  result
+];
+
+processIntegerOption: [
+  text:option:;;
+  parserResult: text parseIntegerOption;
+  parserResult.error "" = ~ [
+    ("Invalid argument value: " text ", " parserResult.error LF) printList
+    FALSE !success
+  ] [
+    parserResult.value @option set
+  ] if
+];
+
 {argc: 0; argv: 0nx;} 0 {convention: cdecl;} [
   ("Start mplc compiler") addLog
   [
@@ -81,12 +140,16 @@ createDefinition: [
 
     success: TRUE dynamic;
 
-    OPT_ANY:                [0 dynamic];
-    OPT_OUTPUT_FILE_NAME:   [1 dynamic];
-    OPT_LINKER_OPTION:      [3 dynamic];
-    OPT_DEFINITION:         [4 dynamic];
-    OPT_ARRAY_CHECK:        [5 dynamic];
-    OPT_CALL_TRACE:         [6 dynamic];
+    OPT_ANY:                       [0 dynamic];
+    OPT_OUTPUT_FILE_NAME:          [1 dynamic];
+    OPT_LINKER_OPTION:             [3 dynamic];
+    OPT_DEFINITION:                [4 dynamic];
+    OPT_ARRAY_CHECK:               [5 dynamic];
+    OPT_CALL_TRACE:                [6 dynamic];
+    OPT_RECURSION_DEPTH_LIMIT:     [7 dynamic];
+    OPT_PRE_RECURSION_DEPTH_LIMIT: [8 dynamic];
+    OPT_STATIC_LOOP_LENGTH_LIMIT:  [9 dynamic];
+
     nextOption: OPT_ANY;
 
     options: ProcessorOptions;
@@ -124,20 +187,23 @@ createDefinition: [
               nextOption (
                 OPT_ANY [
                   option (
-                    "-auto_recursion" [TRUE              @options.!autoRecursion]
-                    "-ndebug"         [FALSE             @options.!debug]
-                    "-logs"           [TRUE              @options.!logs]
-                    "-statlit"        [TRUE              @options.!staticLiterals]
-                    "-dynalit"        [FALSE             @options.!staticLiterals]
-                    "-32bits"         [32nx              @options.!pointerSize]
-                    "-64bits"         [64nx              @options.!pointerSize]
-                    "-verbose_ir"     [TRUE              @options.!verboseIR]
-                    "-version"        [TRUE                 !hasVersion]
-                    "-linker_option"  [OPT_LINKER_OPTION    !nextOption]
-                    "-o"              [OPT_OUTPUT_FILE_NAME !nextOption]
-                    "-D"              [OPT_DEFINITION       !nextOption]
-                    "-array_checks"   [OPT_ARRAY_CHECK      !nextOption]
-                    "-call_trace"     [OPT_CALL_TRACE       !nextOption]
+                    "-auto_recursion"            [TRUE              @options.!autoRecursion]
+                    "-ndebug"                    [FALSE             @options.!debug]
+                    "-logs"                      [TRUE              @options.!logs]
+                    "-statlit"                   [TRUE              @options.!staticLiterals]
+                    "-dynalit"                   [FALSE             @options.!staticLiterals]
+                    "-32bits"                    [32nx              @options.!pointerSize]
+                    "-64bits"                    [64nx              @options.!pointerSize]
+                    "-verbose_ir"                [TRUE              @options.!verboseIR]
+                    "-version"                   [TRUE                          !hasVersion]
+                    "-linker_option"             [OPT_LINKER_OPTION             !nextOption]
+                    "-o"                         [OPT_OUTPUT_FILE_NAME          !nextOption]
+                    "-D"                         [OPT_DEFINITION                !nextOption]
+                    "-array_checks"              [OPT_ARRAY_CHECK               !nextOption]
+                    "-call_trace"                [OPT_CALL_TRACE                !nextOption]
+                    "-pre_recursion_depth_limit" [OPT_PRE_RECURSION_DEPTH_LIMIT !nextOption]
+                    "-recursion_depth_limit"     [OPT_RECURSION_DEPTH_LIMIT     !nextOption]
+                    "-static_loop_length_limit"  [OPT_STATIC_LOOP_LENGTH_LIMIT  !nextOption]
                     [
                       0 splittedOption.chars.at "-" = [
                         "Invalid argument: " print option print LF print
@@ -152,15 +218,15 @@ createDefinition: [
                   option toString @outputFileName set
                   OPT_ANY !nextOption
                 ]
-                OPT_LINKER_OPTION   [
+                OPT_LINKER_OPTION [
                   option toString @options.@linkerOptions.pushBack
                   OPT_ANY !nextOption
                 ]
-                OPT_DEFINITION     [
+                OPT_DEFINITION [
                   splittedOption createDefinition
                   OPT_ANY !nextOption
                 ]
-                OPT_ARRAY_CHECK     [
+                OPT_ARRAY_CHECK [
                   option (
                     "0"   [0 @forceArrayChecks set]
                     "1"   [1 @forceArrayChecks set]
@@ -171,7 +237,7 @@ createDefinition: [
                   ) case
                   OPT_ANY !nextOption
                 ]
-                OPT_CALL_TRACE     [
+                OPT_CALL_TRACE [
                   option (
                     "0"   [0 @forceCallTrace set]
                     "1"   [1 @forceCallTrace set]
@@ -181,6 +247,18 @@ createDefinition: [
                       FALSE @success set
                     ]
                   ) case
+                  OPT_ANY !nextOption
+                ]
+                OPT_RECURSION_DEPTH_LIMIT [
+                  option @options.@recursionDepthLimit processIntegerOption
+                  OPT_ANY !nextOption
+                ]
+                OPT_PRE_RECURSION_DEPTH_LIMIT [
+                  option @options.@preRecursionDepthLimit processIntegerOption
+                  OPT_ANY !nextOption
+                ]
+                OPT_STATIC_LOOP_LENGTH_LIMIT [
+                  option @options.@staticLoopLengthLimit processIntegerOption
                   OPT_ANY !nextOption
                 ]
                 []

--- a/processSubNodes.mpl
+++ b/processSubNodes.mpl
@@ -1753,8 +1753,6 @@ processIf: [
 
 ];
 
-maxLoopLength: [64 dynamic];
-
 processLoop: [
   astNode:;
   indexArray: AstNodeType.Code astNode.data.get;
@@ -1815,9 +1813,9 @@ processLoop: [
     ] &&
 
     iterationNumber 1 + @iterationNumber set
-    iterationNumber maxLoopLength > [
+    iterationNumber processor.options.staticLoopLengthLimit > [
       TRUE @processorResult.!passErrorThroughPRE
-      "static loop length too big, did you forget to add \"dynamic\"?" makeStringView compilerError
+      ("Static loop length limit (" processor.options.staticLoopLengthLimit ") exceeded. Dynamize loop or increase limit using -static_loop_lenght_limit option") assembleString compilerError
     ] when
 
     compilable and
@@ -1981,7 +1979,7 @@ processDynamicLoop: [
 
           newNodeIndex deleteNode
 
-          iterationNumber maxLoopLength > [
+          iterationNumber processor.options.staticLoopLengthLimit > [
             "loop dynamisation iteration count so big" compilerError
           ] when
         ] when

--- a/processor.mpl
+++ b/processor.mpl
@@ -18,21 +18,21 @@ DEFAULT_RECURSION_DEPTH_LIMIT: [256];
 DEFAULT_PRE_RECURSION_DEPTH_LIMIT: [64];
 
 ProcessorOptions: [{
-  mainPath:       String;
-  fileNames:      StringArray;
-  pointerSize:    64nx dynamic;
-  staticLiterals: TRUE dynamic;
-  debug:          TRUE dynamic;
-  arrayChecks:    TRUE dynamic;
-  autoRecursion:  FALSE dynamic;
-  logs:           FALSE dynamic;
-  verboseIR:      FALSE dynamic;
-  callTrace:      FALSE dynamic;
-  threadModel:    0 dynamic;
-  staticLoopLengthLimit: DEFAULT_STATIC_LOOP_LENGTH_LIMIT;
-  recursionDepthLimit: DEFAULT_RECURSION_DEPTH_LIMIT;
+  mainPath:               String;
+  fileNames:              StringArray;
+  pointerSize:            64nx dynamic;
+  staticLiterals:         TRUE dynamic;
+  debug:                  TRUE dynamic;
+  arrayChecks:            TRUE dynamic;
+  autoRecursion:          FALSE dynamic;
+  logs:                   FALSE dynamic;
+  verboseIR:              FALSE dynamic;
+  callTrace:              FALSE dynamic;
+  threadModel:            0 dynamic;
+  staticLoopLengthLimit:  DEFAULT_STATIC_LOOP_LENGTH_LIMIT;
+  recursionDepthLimit:    DEFAULT_RECURSION_DEPTH_LIMIT;
   preRecursionDepthLimit: DEFAULT_PRE_RECURSION_DEPTH_LIMIT;
-  linkerOptions:  String Array;
+  linkerOptions:          String Array;
 }];
 
 ProcessorErrorInfo: [{

--- a/processor.mpl
+++ b/processor.mpl
@@ -13,6 +13,10 @@ CompilerPositionInfo: [{
 
 StringArray: [String Array];
 
+DEFAULT_STATIC_LOOP_LENGTH_LIMIT: [64];
+DEFAULT_RECURSION_DEPTH_LIMIT: [256];
+DEFAULT_PRE_RECURSION_DEPTH_LIMIT: [64];
+
 ProcessorOptions: [{
   mainPath:       String;
   fileNames:      StringArray;
@@ -25,6 +29,9 @@ ProcessorOptions: [{
   verboseIR:      FALSE dynamic;
   callTrace:      FALSE dynamic;
   threadModel:    0 dynamic;
+  staticLoopLengthLimit: DEFAULT_STATIC_LOOP_LENGTH_LIMIT;
+  recursionDepthLimit: DEFAULT_RECURSION_DEPTH_LIMIT;
+  preRecursionDepthLimit: DEFAULT_PRE_RECURSION_DEPTH_LIMIT;
   linkerOptions:  String Array;
 }];
 


### PR DESCRIPTION
There are several limits in the compiler: static loop length limit, recursion depth limit, PRE recursion depth limit. They prevent the compiler from stuck in endless loops. An error saying that one of the limits was exceeded means that the program forces compiler to evaluate an endless loop or that the program requires one of the limits to be greater. This pull request adds command-line options that allow changing these limits.

New options:
* `-pre_recursion_depth_limit <number>` sets PRE recursion depth limit
* `-recursion_depth_limit <number>` sets recursion depth limit
* `-static_loop_length_limit <number>`  sets static loop length limit

`<number>` is non-negative decimal  without leading zeros