### PR TITLE
Fix that built-in function @ would not reify virtual values

### DIFF
--- a/builtinImpl.mpl
+++ b/builtinImpl.mpl
@@ -680,6 +680,7 @@ mplBuiltinProcessAtList: [
 [
   field: mplBuiltinProcessAtList;
   compilable [
+    field isVirtual [field makeVirtualVarReal @field set] when
     field derefAndPush
   ] when
 ] "mplBuiltinAt" @declareBuiltin ucall


### PR DESCRIPTION
Closes #6 

The built-in function `@` would not reify return value if the accessed field was virtual. So this PR just adds the code that reifies virtual values in`@` implementation.