### PR TITLE
Workaround for #55

### DIFF
--- a/processorImpl.mpl
+++ b/processorImpl.mpl
@@ -196,7 +196,7 @@ debugMemory [
           @processor.result.@errorInfo.@missedModule @a @dependedFiles.insert
         ] if
 
-        cachedGlobalErrorInfoSize @processor.@result clearProcessorResult
+        -1 @processor.@result clearProcessorResult
       ] [
         moduleName: file.name;
         ("compiled file " moduleName) addLog


### PR DESCRIPTION
Note, the error is fixed, but in some cases the compiler will produce redundant error messages. See an attachment for further details.
[no_names_match.zip](https://github.com/Matway/mpl-c/files/6516623/no_names_match.zip)
